### PR TITLE
Add JWT auth for API; update GET access in config

### DIFF
--- a/Api/EnvInfoFunction.cs
+++ b/Api/EnvInfoFunction.cs
@@ -19,6 +19,12 @@ namespace Api
         [Function(nameof(EnvInfo))]
         public async Task<HttpResponseData> EnvInfo([HttpTrigger(AuthorizationLevel.Anonymous, "get", "post")] HttpRequestData req)
         {
+            if (!SwaAuthHelper.IsAuthorized(req, _logger))
+            {
+                var unauthorized = req.CreateResponse(HttpStatusCode.Unauthorized);
+                return unauthorized;
+            }
+
             var response = req.CreateResponse(HttpStatusCode.OK);
             try
             {

--- a/Api/QueryPix.cs
+++ b/Api/QueryPix.cs
@@ -42,6 +42,12 @@ namespace Api
         public async Task<HttpResponseData> QueryPix(
             [HttpTrigger(AuthorizationLevel.Anonymous, "get")] HttpRequestData req)
         {
+            if (!SwaAuthHelper.IsAuthorized(req, _logger))
+            {
+                var unauthorized = req.CreateResponse(HttpStatusCode.Unauthorized);
+                return unauthorized;
+            }
+
             var response = req.CreateResponse(HttpStatusCode.OK);
             try
             {

--- a/Api/SwaAuthHelper.cs
+++ b/Api/SwaAuthHelper.cs
@@ -40,20 +40,22 @@ namespace Api
                 logger.LogInformation("[SwaAuth] No x-ms-client-principal — checking Bearer JWT (MSAL flow)");
             }
 
-            // SWA strips all custom request headers before forwarding to Functions.
-            // Token is passed as query parameter "t" instead.
-            var query = System.Web.HttpUtility.ParseQueryString(req.Url.Query);
-            var qtoken = query["t"];
-            if (!string.IsNullOrEmpty(qtoken))
+            // SWA strips custom request headers but the Authorization header reaches the function.
+            // Try to decode it as an AAD JWT.
+            if (req.Headers.TryGetValues("Authorization", out var authValues))
             {
-                var email = GetEmailFromJwt(qtoken, logger);
-                if (email != null && AllowedEmails.Contains(email))
+                var bearer = authValues.FirstOrDefault();
+                if (bearer != null && bearer.StartsWith("Bearer ", StringComparison.OrdinalIgnoreCase))
                 {
-                    logger.LogInformation("[SwaAuth] Authorized via query token email: {email}", email);
-                    return true;
+                    var jwtToken = bearer["Bearer ".Length..].Trim();
+                    var email = GetEmailFromJwt(jwtToken, logger);
+                    if (email != null && AllowedEmails.Contains(email))
+                    {
+                        logger.LogInformation("[SwaAuth] Authorized via Authorization JWT email: {email}", email);
+                        return true;
+                    }
+                    logger.LogWarning("[SwaAuth] Authorization JWT email '{email}' not in allowlist", email ?? "(null)");
                 }
-                logger.LogWarning("[SwaAuth] Query token email '{email}' not in allowlist", email ?? "(null)");
-                return false;
             }
 
             logger.LogWarning("[SwaAuth] No x-ms-client-principal or t= query token — unauthorized");

--- a/Client/staticwebapp.config.json
+++ b/Client/staticwebapp.config.json
@@ -27,8 +27,7 @@
     },
     {
       "route": "/api/*",
-      "methods": [ "GET" ],
-      "allowedRoles": [ "owner", "pictureQuery" ]
+      "methods": [ "GET" ]
     },
     {
       "route": "/api/*",


### PR DESCRIPTION
Added authorization checks to EnvInfo and QueryPix functions, returning 401 if unauthorized. Updated SwaAuthHelper to validate Bearer JWT from Authorization header. Removed allowedRoles restriction for GET /api/* in staticwebapp.config.json, allowing public GET access while keeping role checks for other methods.