### PR TITLE
Update auth to use t= query param for SWA compatibility

### DIFF
--- a/Api/SwaAuthHelper.cs
+++ b/Api/SwaAuthHelper.cs
@@ -40,25 +40,24 @@ namespace Api
                 logger.LogInformation("[SwaAuth] No x-ms-client-principal — checking Bearer JWT (MSAL flow)");
             }
 
-            // SWA strips custom request headers but the Authorization header reaches the function.
-            // Try to decode it as an AAD JWT.
-            if (req.Headers.TryGetValues("Authorization", out var authValues))
+            // SWA replaces the Authorization header with an internal token.
+            // The MSAL token is passed as a &t= query parameter instead.
+            var query = System.Web.HttpUtility.ParseQueryString(req.Url.Query);
+            var tParam = query["t"];
+            if (!string.IsNullOrEmpty(tParam))
             {
-                var bearer = authValues.FirstOrDefault();
-                if (bearer != null && bearer.StartsWith("Bearer ", StringComparison.OrdinalIgnoreCase))
+                var email = GetEmailFromJwt(tParam, logger);
+                if (email != null && AllowedEmails.Contains(email))
                 {
-                    var jwtToken = bearer["Bearer ".Length..].Trim();
-                    var email = GetEmailFromJwt(jwtToken, logger);
-                    if (email != null && AllowedEmails.Contains(email))
-                    {
-                        logger.LogInformation("[SwaAuth] Authorized via Authorization JWT email: {email}", email);
-                        return true;
-                    }
-                    logger.LogWarning("[SwaAuth] Authorization JWT email '{email}' not in allowlist", email ?? "(null)");
+                    logger.LogInformation("[SwaAuth] Authorized via t= JWT email: {email}", email);
+                    return true;
                 }
+                logger.LogWarning("[SwaAuth] t= JWT email '{email}' not in allowlist", email ?? "(null)");
             }
-
-            logger.LogWarning("[SwaAuth] No x-ms-client-principal or t= query token — unauthorized");
+            else
+            {
+                logger.LogWarning("[SwaAuth] No x-ms-client-principal or t= query token — unauthorized");
+            }
             return false;
         }
 

--- a/Client/Pages/PictureQuery.razor.cs
+++ b/Client/Pages/PictureQuery.razor.cs
@@ -493,8 +493,9 @@ public partial class PictureQuery : IDisposable
     {
         for (int attempt = 0; attempt < 2; attempt++)
         {
-            var request = new HttpRequestMessage(HttpMethod.Get, urlQuery);
-            request.Headers.Authorization = new System.Net.Http.Headers.AuthenticationHeaderValue("Bearer", token);
+            // Include token as query param — SWA replaces the Authorization header
+            var url = urlQuery.Contains("&t=") ? urlQuery : urlQuery + $"&t={Uri.EscapeDataString(token)}";
+            var request = new HttpRequestMessage(HttpMethod.Get, url);
             var response = await Http.SendAsync(request);
             var body = await response.Content.ReadAsStringAsync();
 
@@ -699,11 +700,10 @@ public partial class PictureQuery : IDisposable
                 qpart += $"&MediaType={mediaType.ToLower()}";
             }
 
-            // Don't pass album creation to server - we'll handle it client-side
-            var urlQuery = $"/api/QueryPix?{qpart}";
+            // SWA replaces the Authorization header — pass the MSAL token as a query param instead.
+            var urlQuery = $"/api/QueryPix?{qpart}&t={Uri.EscapeDataString(token)}";
 
             var request = new HttpRequestMessage(HttpMethod.Get, urlQuery);
-            request.Headers.Authorization = new System.Net.Http.Headers.AuthenticationHeaderValue("Bearer", token);
             var response = await Http.SendAsync(request);
             var serverJson = await response.Content.ReadAsStringAsync();
             if (response.StatusCode != System.Net.HttpStatusCode.OK)


### PR DESCRIPTION
Switch authentication from Authorization header to t= query parameter for Azure Static Web Apps. Backend now validates JWT from t= param, and frontend appends token as t= in API requests to ensure proper authentication flow with SWA.