### PR TITLE
Switch SWA auth to &u= email param, drop &t= JWT

### DIFF
--- a/Api/SwaAuthHelper.cs
+++ b/Api/SwaAuthHelper.cs
@@ -40,24 +40,21 @@ namespace Api
                 logger.LogInformation("[SwaAuth] No x-ms-client-principal — checking Bearer JWT (MSAL flow)");
             }
 
-            // SWA replaces the Authorization header with an internal token.
-            // The MSAL token is passed as a &t= query parameter instead.
+            // SWA replaces the Authorization header — identity is passed as &u= query param.
             var query = System.Web.HttpUtility.ParseQueryString(req.Url.Query);
-            var tParam = query["t"];
-            if (!string.IsNullOrEmpty(tParam))
+            var userEmail = query["u"];
+            if (!string.IsNullOrEmpty(userEmail))
             {
-                var email = GetEmailFromJwt(tParam, logger);
-                if (email != null && AllowedEmails.Contains(email))
+                logger.LogInformation("[SwaAuth] &u= param: '{email}'", userEmail);
+                if (AllowedEmails.Contains(userEmail))
                 {
-                    logger.LogInformation("[SwaAuth] Authorized via t= JWT email: {email}", email);
+                    logger.LogInformation("[SwaAuth] Authorized via &u= email: {email}", userEmail);
                     return true;
                 }
-                logger.LogWarning("[SwaAuth] t= JWT email '{email}' not in allowlist", email ?? "(null)");
+                logger.LogWarning("[SwaAuth] &u= email '{email}' not in allowlist", userEmail);
             }
-            else
-            {
-                logger.LogWarning("[SwaAuth] No x-ms-client-principal or t= query token — unauthorized");
-            }
+
+            logger.LogWarning("[SwaAuth] No x-ms-client-principal or &u= param — unauthorized");
             return false;
         }
 

--- a/Client/Pages/PictureQuery.razor.cs
+++ b/Client/Pages/PictureQuery.razor.cs
@@ -32,6 +32,7 @@ public partial class PictureQuery : IDisposable
     // Owner identity
     private const string OwnerEmail = "calvin_hsia@live.com";
     private bool isGuestUser = false;
+    private string userMail = string.Empty;
 
     // Private fields
     private int NumberRowsPerPage = 10;
@@ -163,7 +164,7 @@ public partial class PictureQuery : IDisposable
                 // 3. userPrincipalName (may be mangled for MSA, but use as last resort)
                 candidates.Add(root.TryGetProperty("userPrincipalName", out var upnEl) ? upnEl.GetString() : null);
 
-                var userMail = candidates.FirstOrDefault(c => !string.IsNullOrWhiteSpace(c));
+                userMail = candidates.FirstOrDefault(c => !string.IsNullOrWhiteSpace(c)) ?? string.Empty;
                 Console.WriteLine($"Signed-in user resolved to: '{userMail}'");
                 isGuestUser = !string.Equals(userMail, OwnerEmail, StringComparison.OrdinalIgnoreCase);
 
@@ -493,8 +494,8 @@ public partial class PictureQuery : IDisposable
     {
         for (int attempt = 0; attempt < 2; attempt++)
         {
-            // Include token as query param — SWA replaces the Authorization header
-            var url = urlQuery.Contains("&t=") ? urlQuery : urlQuery + $"&t={Uri.EscapeDataString(token)}";
+            // Include user email as &u= — SWA replaces Authorization header so we can't use it
+            var url = urlQuery.Contains("&u=") ? urlQuery : urlQuery + $"&u={Uri.EscapeDataString(userMail)}";
             var request = new HttpRequestMessage(HttpMethod.Get, url);
             var response = await Http.SendAsync(request);
             var body = await response.Content.ReadAsStringAsync();
@@ -700,8 +701,8 @@ public partial class PictureQuery : IDisposable
                 qpart += $"&MediaType={mediaType.ToLower()}";
             }
 
-            // SWA replaces the Authorization header — pass the MSAL token as a query param instead.
-            var urlQuery = $"/api/QueryPix?{qpart}&t={Uri.EscapeDataString(token)}";
+            // SWA replaces the Authorization header — pass the email as a query param instead.
+            var urlQuery = $"/api/QueryPix?{qpart}&u={Uri.EscapeDataString(userMail)}";
 
             var request = new HttpRequestMessage(HttpMethod.Get, urlQuery);
             var response = await Http.SendAsync(request);


### PR DESCRIPTION
Updated SWA authentication to use the user email (&u=) query parameter instead of the MSAL JWT token (&t=). SwaAuthHelper now validates &u= against the allowlist. PictureQuery.razor.cs resolves and passes user email in all API requests. Updated related comments and logging.