### PR TITLE
Add Application Insights telemetry integration

### DIFF
--- a/Client/App.razor
+++ b/Client/App.razor
@@ -1,4 +1,5 @@
 ﻿<CascadingAuthenticationState>
+    <Client.Shared.TelemetryErrorBoundary>
     <Router AppAssembly="@typeof(App).Assembly">
         <Found Context="routeData">
             <AuthorizeRouteView RouteData="@routeData" DefaultLayout="@typeof(MainLayout)">
@@ -22,4 +23,5 @@
             </LayoutView>
         </NotFound>
     </Router>
+    </Client.Shared.TelemetryErrorBoundary>
 </CascadingAuthenticationState>

--- a/Client/Pages/Ant.razor
+++ b/Client/Pages/Ant.razor
@@ -4,6 +4,7 @@
 @inject IJSRuntime JSRuntime
 @inject RandomService RandomService
 @inject CssLoaderService CssLoader
+@inject Client.Services.ApplicationInsightsLogger AppInsights
 @implements IDisposable
 @attribute [AllowAnonymous]
 
@@ -219,6 +220,7 @@
         {
             // Load CSS on demand
             await CssLoader.LoadCssAsync(GameCss.Ant.Path, GameCss.Ant.Version);
+            _ = AppInsights.TrackPageActivationAsync("Ant");
 
             DebugHelper.Log("[Ant] OnAfterRenderAsync - initializing", true);
 

--- a/Client/Pages/Authentication.razor
+++ b/Client/Pages/Authentication.razor
@@ -5,6 +5,7 @@
 @inject IJSRuntime JS
 @inject AuthenticationStateProvider AuthenticationStateProvider
 @inject IAccessTokenProvider TokenProvider
+@inject Client.Services.ApplicationInsightsLogger AppInsights
 
 <RemoteAuthenticatorView Action="@Action">
     <LoggingIn>
@@ -102,9 +103,17 @@
     {
         Console.WriteLine($"Authentication page loaded with action: {Action}");
         Console.WriteLine($"Current URL: {Navigation.Uri}");
-        
+
         var userAgent = await GetUserAgent();
         debugInfo = $"Action: {Action}\nURL: {Navigation.Uri}\nUserAgent: {userAgent}\nTimestamp: {DateTime.Now:yyyy-MM-dd HH:mm:ss}";
+
+        // Fire telemetry for the auth action that brought us here
+        if (Action?.ToLower() is "login" or "login-callback")
+            _ = AppInsights.TrackLoginAsync("started", $"action={Action}");
+        else if (Action?.ToLower() is "logout" or "logout-callback")
+            _ = AppInsights.TrackLogoutAsync("started", $"action={Action}");
+        else if (Action?.ToLower() == "logged-out")
+            _ = AppInsights.TrackLogoutAsync("success", "logged-out");
         
         // Handle logout completion automatically
         if (Action?.ToLower() == "logout")
@@ -158,6 +167,14 @@
                     Console.WriteLine("Access token retrieved successfully");
                     statusMessage = "Authentication successful! Redirecting...";
                     StateHasChanged();
+
+                    // Resolve username from auth state for the telemetry event
+                    var authStateSuccess = await AuthenticationStateProvider.GetAuthenticationStateAsync();
+                    var successUser = authStateSuccess.User;
+                    var resolvedId = successUser.FindFirst("preferred_username")?.Value
+                                  ?? successUser.FindFirst(System.Security.Claims.ClaimTypes.Name)?.Value
+                                  ?? successUser.Identity?.Name;
+                    _ = AppInsights.TrackLoginAsync("success", "token_ok", resolvedId);
                     
                     await Task.Delay(1000);
                     
@@ -177,6 +194,11 @@
                     Console.WriteLine("User is authenticated via AuthenticationState");
                     statusMessage = "Authentication successful! Redirecting...";
                     StateHasChanged();
+
+                    var resolvedId2 = user.FindFirst("preferred_username")?.Value
+                                   ?? user.FindFirst(System.Security.Claims.ClaimTypes.Name)?.Value
+                                   ?? user.Identity?.Name;
+                    _ = AppInsights.TrackLoginAsync("success", "auth_state_ok", resolvedId2);
                     
                     await Task.Delay(1000);
                     await JS.InvokeVoidAsync("eval", "window.location.href = '/'");
@@ -192,18 +214,21 @@
             // All attempts failed
             statusMessage = "Authentication check failed. You may need to sign in again.";
             debugInfo += $"\nAuth Check Failed: No valid token or authentication state found";
+            _ = AppInsights.TrackLoginAsync("failure", "no_token_after_retries");
         }
         catch (AccessTokenNotAvailableException ex)
         {
             Console.WriteLine($"Access token not available: {ex.Message}");
             statusMessage = "Authentication required. Please sign in again.";
             debugInfo += $"\nAccess Token Error: {ex.Message}";
+            _ = AppInsights.TrackLoginAsync("failure", $"AccessTokenNotAvailable: {ex.Message}");
         }
         catch (Exception ex)
         {
             Console.WriteLine($"Error checking authentication: {ex.Message}");
             statusMessage = $"Error checking authentication: {ex.Message}";
             debugInfo += $"\nError: {ex.Message}";
+            _ = AppInsights.TrackLoginAsync("failure", ex.Message);
         }
         finally
         {
@@ -257,11 +282,13 @@
             
             // Small delay then redirect
             await Task.Delay(100);
+            _ = AppInsights.TrackLogoutAsync("success", "storage_cleared");
             await JS.InvokeVoidAsync("eval", "window.location.href = '/'");
         }
         catch (Exception ex)
         {
             Console.WriteLine($"Error during force logout: {ex.Message}");
+            _ = AppInsights.TrackLogoutAsync("failure", ex.Message);
             await JS.InvokeVoidAsync("eval", "window.location.href = '/'");
         }
     }

--- a/Client/Pages/Bounce.razor
+++ b/Client/Pages/Bounce.razor
@@ -5,6 +5,7 @@
 @inject DebugHelper DebugHelper
 @inject RandomService RandomService
 @inject CssLoaderService CssLoader
+@inject Client.Services.ApplicationInsightsLogger AppInsights
 @implements IDisposable
 @attribute [AllowAnonymous]
 
@@ -168,6 +169,7 @@
 		{
 			// Load CSS on demand
 			await CssLoader.LoadCssAsync(GameCss.Bounce.Path, GameCss.Bounce.Version);
+			_ = AppInsights.TrackPageActivationAsync("Bounce");
 
 			DebugHelper.Log("[Bounce] OnAfterRenderAsync - First render starting", true);
 

--- a/Client/Pages/Cartoon.razor
+++ b/Client/Pages/Cartoon.razor
@@ -9,6 +9,7 @@
 @inject CartoonService CartoonService
 @inject NavigationManager NavigationManager
 @inject CssLoaderService CssLoader
+@inject Client.Services.ApplicationInsightsLogger AppInsights
 @implements IDisposable
 @attribute [AllowAnonymous]
 
@@ -247,6 +248,7 @@
 				{
 					finalMessage = urlMessage;
 				}
+				_ = AppInsights.TrackPageActivationAsync("Cartoon", new Dictionary<string, string> { { "message", finalMessage ?? string.Empty } });
 
 				// Apply URL parameters if provided (before loading message)
 				if (!string.IsNullOrWhiteSpace(urlThickness) && double.TryParse(urlThickness, out var thickness))

--- a/Client/Pages/Fish.razor
+++ b/Client/Pages/Fish.razor
@@ -6,6 +6,7 @@
 @inject DebugHelper DebugHelper
 @inject RandomService RandomService
 @inject CssLoaderService CssLoader
+@inject Client.Services.ApplicationInsightsLogger AppInsights
 @implements IDisposable
 @attribute [AllowAnonymous]
 
@@ -236,6 +237,7 @@
 
 			// Load CSS on demand
 			await CssLoader.LoadCssAsync(GameCss.Fish.Path, GameCss.Fish.Version);
+			_ = AppInsights.TrackPageActivationAsync("Fish");
 
 			try
 			{

--- a/Client/Pages/FreeCell.razor
+++ b/Client/Pages/FreeCell.razor
@@ -10,6 +10,7 @@
 @inject GameStateService GameStateService
 @inject NavigationManager NavigationManager
 @inject CssLoaderService CssLoader
+@inject Client.Services.ApplicationInsightsLogger AppInsights
 @using System.Text.Json
 @implements IAsyncDisposable
 @attribute [AllowAnonymous]
@@ -533,6 +534,7 @@
             await CssLoader.LoadCssFilesAsync(
                 (GameCss.PlayingCards.Path, GameCss.PlayingCards.Version),
                 (GameCss.FreeCell.Path, GameCss.FreeCell.Version));
+            _ = AppInsights.TrackPageActivationAsync("FreeCell");
 
             // Load saved settings
             var savedSettings = await GameStateService.LoadFreeCellSettingsAsync();

--- a/Client/Pages/Hearts.razor
+++ b/Client/Pages/Hearts.razor
@@ -7,6 +7,7 @@
 @inject DebugHelper DebugHelper
 @inject RandomService RandomService
 @inject CssLoaderService CssLoader
+@inject Client.Services.ApplicationInsightsLogger AppInsights
 @implements IAsyncDisposable
 @attribute [AllowAnonymous]
 
@@ -222,6 +223,7 @@
             await CssLoader.LoadCssFilesAsync(
                 (GameCss.PlayingCards.Path, GameCss.PlayingCards.Version),
                 (GameCss.Hearts.Path, GameCss.Hearts.Version));
+            _ = AppInsights.TrackPageActivationAsync("Hearts");
 
             _dotNetRef = DotNetObjectReference.Create(this);
             DebugHelper.Log("[Hearts] Component rendered", true);

--- a/Client/Pages/Life.razor
+++ b/Client/Pages/Life.razor
@@ -4,6 +4,7 @@
 @inject IJSRuntime JSRuntime
 @inject RandomService RandomService
 @inject CssLoaderService CssLoader
+@inject Client.Services.ApplicationInsightsLogger AppInsights
 @implements IDisposable
 @attribute [AllowAnonymous]
 
@@ -304,6 +305,7 @@
         {
             // Load CSS on demand
             await CssLoader.LoadCssAsync(GameCss.Life.Path, GameCss.Life.Version);
+            _ = AppInsights.TrackPageActivationAsync("Life");
 
             DebugHelper.Log("[Life] OnAfterRenderAsync - initializing", true);
 

--- a/Client/Pages/LoginPage.razor
+++ b/Client/Pages/LoginPage.razor
@@ -1,6 +1,7 @@
 ﻿@page "/LoginPage"
 @using Microsoft.AspNetCore.Components.WebAssembly.Authentication
 @inject NavigationManager Navigation
+@inject Client.Services.ApplicationInsightsLogger AppInsights
 
 <h3>Login</h3>
 
@@ -15,8 +16,9 @@
 </div>
 
 @code {
-    private void BeginSignIn()
+    private async Task BeginSignIn()
     {
+        await AppInsights.TrackLoginAsync("initiated", "user_clicked_sign_in");
         Navigation.NavigateToLogin("authentication/login");
     }
 }

--- a/Client/Pages/LogoGame.razor
+++ b/Client/Pages/LogoGame.razor
@@ -10,6 +10,7 @@
 @inject NavigationManager NavigationManager
 @inject TelemetryService TelemetryService
 @inject CssLoaderService CssLoader
+@inject Client.Services.ApplicationInsightsLogger AppInsights
 @implements IDisposable
 @attribute [AllowAnonymous]
 
@@ -890,15 +891,8 @@
 			_pageLoadTime = DateTime.Now.ToString("HH:mm:ss.fff");
 			_componentRenderTime = DateTime.Now.ToString("HH:mm:ss.fff");
 
-			// Track page load event (telemetry already initialized globally)
-			try
-			{
-				await TelemetryService.TrackEventAsync("LogoGame_Loaded");
-			}
-			catch (Exception ex)
-			{
-				DebugHelper.LogError($"Failed to track LogoGame load event: {ex.Message}");
-			}
+			// Track page activation
+			_ = AppInsights.TrackPageActivationAsync("Logo");
 
 			StateHasChanged();
 

--- a/Client/Pages/Mandelbrot.razor
+++ b/Client/Pages/Mandelbrot.razor
@@ -4,6 +4,7 @@
 @inject IJSRuntime JSRuntime
 @inject DebugHelper DebugHelper
 @inject CssLoaderService CssLoader
+@inject Client.Services.ApplicationInsightsLogger AppInsights
 @implements IDisposable
 @attribute [AllowAnonymous]
 
@@ -133,6 +134,7 @@
         {
             // Load CSS on demand
             await CssLoader.LoadCssAsync(GameCss.Mandelbrot.Path, GameCss.Mandelbrot.Version);
+            _ = AppInsights.TrackPageActivationAsync("Mandelbrot");
 
             DebugHelper.Log("[Mandelbrot] OnAfterRenderAsync - initializing", true);
 

--- a/Client/Pages/Minesweeper.razor
+++ b/Client/Pages/Minesweeper.razor
@@ -5,6 +5,7 @@
 @inject DebugHelper DebugHelper
 @inject GameStateService StateService
 @inject CssLoaderService CssLoader
+@inject Client.Services.ApplicationInsightsLogger AppInsights
 @implements IDisposable
 @attribute [AllowAnonymous]
 
@@ -129,6 +130,7 @@
         {
             // Load CSS on demand
             await CssLoader.LoadCssAsync(GameCss.Minesweeper.Path, GameCss.Minesweeper.Version);
+            _ = AppInsights.TrackPageActivationAsync("Minesweeper");
 
             DebugHelper.Log("[Minesweeper] OnAfterRenderAsync - initializing", true);
 

--- a/Client/Pages/PictureQuery.razor
+++ b/Client/Pages/PictureQuery.razor
@@ -154,19 +154,32 @@
             }
             var cntr = 0;
         }
-        <div id="MyMain" style="display:none">
-            <p>
-                <img id="imageMain" />
-                <video width="320" height="240" id="myVideo" controls style="display:none">
-                    video tag not supported
-                </video>
-                <button @onclick="MyImgClickMain">Download</button>
-                @if (mainPix != null)
+        <div id="lightbox" class="lightbox-overlay @(showLightbox ? "lightbox-visible" : "")">
+            <div class="lightbox-toolbar">
+                <button class="lightbox-btn" @onclick="LightboxClose">← Back</button>
+                <span class="lightbox-title">@mainPix?.AltText</span>
+                <button class="lightbox-btn" @onclick="MyImgClickMain" disabled="@(mainPix == null)">⬇ Download</button>
+            </div>
+            <div class="lightbox-body">
+                <div class="lightbox-media" id="lightboxMedia">
+                    <img id="imageMain" class="lightbox-img" />
+                    <video id="myVideo" class="lightbox-video" controls>
+                        video tag not supported
+                    </video>
+                    <button class="lightbox-nav lightbox-prev" @onclick="LightboxPrev" disabled="@(lightboxIndex <= 0)">❮</button>
+                    <button class="lightbox-nav lightbox-next" @onclick="LightboxNext" disabled="@(lightboxIndex >= myPixes.Count - 1)">❯</button>
+                </div>
+            </div>
+            <div class="lightbox-footer">
+                <span class="lightbox-counter">@(lightboxIndex + 1) / @myPixes.Count</span>
+                @if (myPixes.Count > 1)
                 {
-                    <label>@mainPix.AltText</label>
+                    <input type="range" class="lightbox-slider" min="0" max="@(myPixes.Count - 1)"
+                           value="@lightboxIndex"
+                           @oninput="OnSliderInput"
+                           @onchange="OnSliderChange" />
                 }
-            </p>
-
+            </div>
         </div>
 
         @if (isLoading)
@@ -207,6 +220,140 @@
 </AuthorizeView>
 
 <style>
+    .lightbox-overlay {
+        display: none;
+        position: fixed;
+        top: 0; left: 0; right: 0; bottom: 0;
+        background: #000;
+        z-index: 9999;
+        flex-direction: column;
+    }
+
+    .lightbox-visible {
+        display: flex !important;
+    }
+
+    .lightbox-toolbar {
+        display: flex;
+        align-items: center;
+        justify-content: space-between;
+        padding: 6px 12px;
+        background: rgba(0,0,0,0.85);
+        color: white;
+        flex-shrink: 0;
+        min-height: 44px;
+    }
+
+    .lightbox-title {
+        flex: 1;
+        text-align: center;
+        font-size: 13px;
+        overflow: hidden;
+        text-overflow: ellipsis;
+        white-space: nowrap;
+        padding: 0 10px;
+        color: #ddd;
+    }
+
+    .lightbox-btn {
+        background: rgba(255,255,255,0.15);
+        color: white;
+        border: 1px solid rgba(255,255,255,0.3);
+        padding: 5px 12px;
+        border-radius: 4px;
+        cursor: pointer;
+        font-size: 13px;
+        white-space: nowrap;
+    }
+
+    .lightbox-btn:hover:not(:disabled) {
+        background: rgba(255,255,255,0.3);
+    }
+
+    .lightbox-btn:disabled {
+        opacity: 0.4;
+        cursor: default;
+    }
+
+    .lightbox-body {
+        flex: 1;
+        overflow: hidden;
+        position: relative;
+    }
+
+    .lightbox-media {
+        width: 100%;
+        height: 100%;
+        position: relative;
+        display: flex;
+        align-items: center;
+        justify-content: center;
+    }
+
+    .lightbox-img {
+        width: 100%;
+        height: 100%;
+        object-fit: contain;
+        display: none;
+        touch-action: pinch-zoom;
+    }
+
+    .lightbox-video {
+        width: 100%;
+        height: 100%;
+        object-fit: contain;
+        display: none;
+    }
+
+    .lightbox-nav {
+        position: absolute;
+        top: 50%;
+        transform: translateY(-50%);
+        background: rgba(0,0,0,0.45);
+        color: white;
+        border: none;
+        font-size: 2rem;
+        padding: 14px 18px;
+        cursor: pointer;
+        z-index: 10;
+        border-radius: 4px;
+        transition: background 0.2s;
+        line-height: 1;
+    }
+
+    .lightbox-prev { left: 8px; }
+    .lightbox-next { right: 8px; }
+
+    .lightbox-nav:hover:not(:disabled) {
+        background: rgba(0,0,0,0.75);
+    }
+
+    .lightbox-nav:disabled {
+        opacity: 0.15;
+        cursor: default;
+    }
+
+    .lightbox-footer {
+        display: flex;
+        flex-direction: column;
+        align-items: center;
+        gap: 2px;
+        background: rgba(0,0,0,0.75);
+        padding: 4px 12px 6px;
+        flex-shrink: 0;
+    }
+
+    .lightbox-counter {
+        color: rgba(255,255,255,0.7);
+        font-size: 12px;
+    }
+
+    .lightbox-slider {
+        width: min(600px, 90vw);
+        accent-color: #aaa;
+        cursor: pointer;
+    }
+
     .filter-input-container {
         position: relative;
         display: inline-block;
@@ -394,4 +541,88 @@
             }
         });
     }
+
+    // Pinch-zoom for lightbox image (works on desktop with wheel too)
+    if (!window._lightboxZoomInit) {
+        window._lightboxZoomInit = true;
+        window.initLightboxZoom = () => {
+            const img = document.getElementById('imageMain');
+            if (!img || img._zoomInited) return;
+            img._zoomInited = true;
+            let scale = 1, tx = 0, ty = 0;
+            let lastDist = 0, lastTx = 0, lastTy = 0;
+            let pointers = [];
+
+            function applyTransform() {
+                img.style.transform = `translate(${tx}px,${ty}px) scale(${scale})`;
+                img.style.transformOrigin = 'center center';
+            }
+
+            // Mouse wheel zoom (desktop)
+            img.addEventListener('wheel', e => {
+                e.preventDefault();
+                const delta = e.deltaY < 0 ? 1.1 : 0.91;
+                scale = Math.max(1, Math.min(10, scale * delta));
+                if (scale === 1) { tx = 0; ty = 0; }
+                applyTransform();
+            }, { passive: false });
+
+            // Touch events for pinch+pan
+            img.addEventListener('touchstart', e => {
+                pointers = [...e.touches];
+                if (pointers.length === 2) {
+                    lastDist = Math.hypot(
+                        pointers[0].clientX - pointers[1].clientX,
+                        pointers[0].clientY - pointers[1].clientY);
+                }
+                lastTx = tx; lastTy = ty;
+            }, { passive: true });
+
+            img.addEventListener('touchmove', e => {
+                if (e.touches.length === 2) {
+                    e.preventDefault();
+                    const dist = Math.hypot(
+                        e.touches[0].clientX - e.touches[1].clientX,
+                        e.touches[0].clientY - e.touches[1].clientY);
+                    if (lastDist > 0) {
+                        scale = Math.max(1, Math.min(10, scale * (dist / lastDist)));
+                        lastDist = dist;
+                    }
+                    applyTransform();
+                } else if (e.touches.length === 1 && scale > 1) {
+                    e.preventDefault();
+                    const dx = e.touches[0].clientX - pointers[0].clientX;
+                    const dy = e.touches[0].clientY - pointers[0].clientY;
+                    tx = lastTx + dx; ty = lastTy + dy;
+                    applyTransform();
+                }
+            }, { passive: false });
+
+            img.addEventListener('touchend', e => {
+                if (e.touches.length < 2) lastDist = 0;
+                if (scale <= 1) { scale = 1; tx = 0; ty = 0; applyTransform(); }
+                pointers = [...e.touches];
+                lastTx = tx; lastTy = ty;
+            }, { passive: true });
+
+            // Double-tap or double-click to reset zoom
+            let lastTap = 0;
+            img.addEventListener('click', () => {
+                const now = Date.now();
+                if (now - lastTap < 300) { scale = 1; tx = 0; ty = 0; applyTransform(); }
+                lastTap = now;
+            });
+        };
+    }
+
+    // Reset zoom when a new image is set
+    const _origSetImageSrc = window.setImageSrc;
+    window.setImageSrc = async (id, stream) => {
+        await _origSetImageSrc(id, stream);
+        if (id === 'imageMain') {
+            const img = document.getElementById('imageMain');
+            if (img) { img.style.transform = ''; img._zoomInited = false; }
+            setTimeout(() => window.initLightboxZoom && window.initLightboxZoom(), 50);
+        }
+    };
 </script>

--- a/Client/Pages/PictureQuery.razor.cs
+++ b/Client/Pages/PictureQuery.razor.cs
@@ -36,7 +36,7 @@ public partial class PictureQuery : IDisposable
     private string userMail = string.Empty;
 
     // Private fields
-    private int NumberRowsPerPage = 10;
+    private int NumberRowsPerPage = 40;
     private int NumberPerRow = 1; // depends on width of browser
     private int maxpix = 10000; // max # pix per query
 
@@ -60,6 +60,9 @@ public partial class PictureQuery : IDisposable
     private bool isLoading = false;
     private bool albumNameManuallyChanged = false;
     private bool wakeLockActive = false;
+    private bool showLightbox = false;
+    private int lightboxIndex = -1;
+    private int sliderPreviewIndex = -1; // index while slider is dragging
 
     // Filter history fields
     private List<string> filterHistory = new();
@@ -211,6 +214,7 @@ public partial class PictureQuery : IDisposable
     {
         base.OnParametersSet();
         mainPix = null;
+        showLightbox = false;
         _ = JS.InvokeVoidAsync("setImageSrc", "imageMain", "null");
         _ = DoRefreshAsync();
     }
@@ -670,7 +674,9 @@ public partial class PictureQuery : IDisposable
     private async Task resetUI()
     {
         mainPix = null;
-        await JS.InvokeVoidAsync("setElementVisible", "MyMain", "none");
+        showLightbox = false;
+        await JS.InvokeVoidAsync("setImageSrc", "imageMain", "null");
+        await JS.InvokeVoidAsync("setImageSrc", "myVideo", "null");
     }
 
     private async Task DoQueryAsync()
@@ -1146,32 +1152,82 @@ public partial class PictureQuery : IDisposable
 
     private async Task MyThumbClick(MyPix pix)
     {
+        lightboxIndex = myPixes.IndexOf(pix);
+        await ShowLightboxItemAsync(lightboxIndex);
+    }
+
+    private async Task ShowLightboxItemAsync(int index)
+    {
+        if (index < 0 || index >= myPixes.Count) return;
         isLoading = true;
+        showLightbox = true;
+        lightboxIndex = index;
         StateHasChanged();
         try
         {
-            mainPix = pix;
+            mainPix = myPixes[index];
             await Task.Yield();
+            if (mainPix.IsVideo)
             {
-                if (pix.IsVideo)
-                {
-                    var strm = await GetImageStreamAsync(pix, "");
-                    await JS.InvokeVoidAsync("setImageSrc", "imageMain", "null");
-                    await JS.InvokeVoidAsync("setImageSrc", "myVideo", strm);
-                }
-                else
-                {
-                    var dotnetImageStream = await GetImageStreamAsync(pix, "large");
-                    await JS.InvokeVoidAsync("setImageSrc", "myVideo", "null");
-                    await JS.InvokeVoidAsync("setImageSrc", "imageMain", dotnetImageStream);
-                }
-                await JS.InvokeVoidAsync("setElementVisible", "MyMain", "block");
+                var strm = await GetImageStreamAsync(mainPix, "");
+                await JS.InvokeVoidAsync("setImageSrc", "imageMain", "null");
+                await JS.InvokeVoidAsync("setImageSrc", "myVideo", strm);
+            }
+            else
+            {
+                var dotnetImageStream = await GetImageStreamAsync(mainPix, "large");
+                await JS.InvokeVoidAsync("setImageSrc", "myVideo", "null");
+                await JS.InvokeVoidAsync("setImageSrc", "imageMain", dotnetImageStream);
             }
         }
         finally
         {
             isLoading = false;
             StateHasChanged();
+        }
+    }
+
+    private async Task LightboxPrev()
+    {
+        if (lightboxIndex > 0)
+            await ShowLightboxItemAsync(lightboxIndex - 1);
+    }
+
+    private async Task LightboxNext()
+    {
+        if (lightboxIndex < myPixes.Count - 1)
+            await ShowLightboxItemAsync(lightboxIndex + 1);
+    }
+
+    private async Task LightboxClose()
+    {
+        showLightbox = false;
+        mainPix = null;
+        sliderPreviewIndex = -1;
+        await JS.InvokeVoidAsync("setImageSrc", "imageMain", "null");
+        await JS.InvokeVoidAsync("setImageSrc", "myVideo", "null");
+        StateHasChanged();
+    }
+
+    // Slider dragging: update title/counter in real time without loading the image
+    private void OnSliderInput(ChangeEventArgs e)
+    {
+        if (int.TryParse(e.Value?.ToString(), out var idx) && idx >= 0 && idx < myPixes.Count)
+        {
+            sliderPreviewIndex = idx;
+            lightboxIndex = idx;
+            mainPix = myPixes[idx]; // update title immediately
+            StateHasChanged();
+        }
+    }
+
+    // Slider released: load the full image
+    private async Task OnSliderChange(ChangeEventArgs e)
+    {
+        if (int.TryParse(e.Value?.ToString(), out var idx))
+        {
+            sliderPreviewIndex = -1;
+            await ShowLightboxItemAsync(idx);
         }
     }
 

--- a/Client/Pages/PictureQuery.razor.cs
+++ b/Client/Pages/PictureQuery.razor.cs
@@ -20,6 +20,7 @@ public partial class PictureQuery : IDisposable
     [Inject] private IAccessTokenProvider TokenProvider { get; set; } = null!;
     [Inject] private AuthTokenHelper AuthToken { get; set; } = null!;
     [Inject] private AlbumService AlbumService { get; set; } = null!;
+    [Inject] private Client.Services.ApplicationInsightsLogger AppInsights { get; set; } = null!;
 
     // Parameters
     [Parameter]
@@ -87,7 +88,9 @@ public partial class PictureQuery : IDisposable
         // ✅ LOG MYPIX VERSION TO VERIFY CORRECT DLL IS LOADED
         Console.WriteLine($"🔍 MyPix Version Check: {MyPix.MYPIX_VERSION}");
         Console.WriteLine($"🔍 MyPix has parameterless constructor: {typeof(MyPix).GetConstructor(Type.EmptyTypes) != null}");
-        
+
+        _ = AppInsights.TrackPageActivationAsync("PictureQuery");
+
         _httpClient = HttpClientFactory.CreateClient("GraphAPI");
         try
         {
@@ -167,6 +170,7 @@ public partial class PictureQuery : IDisposable
                 userMail = candidates.FirstOrDefault(c => !string.IsNullOrWhiteSpace(c)) ?? string.Empty;
                 Console.WriteLine($"Signed-in user resolved to: '{userMail}'");
                 isGuestUser = !string.Equals(userMail, OwnerEmail, StringComparison.OrdinalIgnoreCase);
+                AppInsights.SetUserId(userMail);
 
                 if (isGuestUser)
                 {
@@ -197,6 +201,7 @@ public partial class PictureQuery : IDisposable
         {
             Console.WriteLine($"Error in OnInitializedAsync: {ex.Message}");
             statusMessage = $"Error: {ex.Message}. Please refresh the page.";
+            _ = AppInsights.TrackErrorAsync("PictureQuery.OnInitializedAsync", ex);
         }
     }
 
@@ -726,6 +731,7 @@ public partial class PictureQuery : IDisposable
             {
                 myPixes.AddRange(pixes);
             }
+            _ = AppInsights.TrackPictureQueryFilterAsync(notesFilter, mediaType, myPixes.Count);
             _ = DoRefreshAsync();
 
             if (myPixes.Count > 0)

--- a/Client/Pages/Snake.razor
+++ b/Client/Pages/Snake.razor
@@ -4,6 +4,7 @@
 @inject IJSRuntime JSRuntime
 @inject DebugHelper DebugHelper
 @inject CssLoaderService CssLoader
+@inject Client.Services.ApplicationInsightsLogger AppInsights
 @implements IDisposable
 @attribute [AllowAnonymous]
 
@@ -117,6 +118,7 @@
         {
             // Load CSS on demand
             await CssLoader.LoadCssAsync(GameCss.Snake.Path, GameCss.Snake.Version);
+            _ = AppInsights.TrackPageActivationAsync("Snake");
 
             DebugHelper.Log("[Snake] OnAfterRenderAsync - initializing", true);
 

--- a/Client/Pages/Solitaire.razor
+++ b/Client/Pages/Solitaire.razor
@@ -8,6 +8,7 @@
 @inject RandomService RandomService
 @inject CssLoaderService CssLoader
 @inject GameStateService GameStateService
+@inject Client.Services.ApplicationInsightsLogger AppInsights
 @implements IAsyncDisposable
 @attribute [AllowAnonymous]
 
@@ -188,6 +189,7 @@
             await CssLoader.LoadCssFilesAsync(
                 (GameCss.PlayingCards.Path, GameCss.PlayingCards.Version),
                 (GameCss.Solitaire.Path, GameCss.Solitaire.Version));
+            _ = AppInsights.TrackPageActivationAsync("Solitaire");
 
             // Load saved settings
             var settings = await GameStateService.LoadSolitaireSettingsAsync();

--- a/Client/Pages/Tetris.razor
+++ b/Client/Pages/Tetris.razor
@@ -4,6 +4,7 @@
 @inject IJSRuntime JSRuntime
 @inject DebugHelper DebugHelper
 @inject CssLoaderService CssLoader
+@inject Client.Services.ApplicationInsightsLogger AppInsights
 @implements IDisposable
 @attribute [AllowAnonymous]
 
@@ -113,6 +114,7 @@
         {
             // Load CSS on demand
             await CssLoader.LoadCssAsync(GameCss.Tetris.Path, GameCss.Tetris.Version);
+            _ = AppInsights.TrackPageActivationAsync("Tetris");
 
             DebugHelper.Log("[Tetris] OnAfterRenderAsync - initializing", true);
 

--- a/Client/Pages/WordScapeGame.razor
+++ b/Client/Pages/WordScapeGame.razor
@@ -9,6 +9,7 @@
 @inject IJSRuntime JSRuntime
 @inject NavigationManager NavigationManager
 @inject CssLoaderService CssLoader
+@inject Client.Services.ApplicationInsightsLogger AppInsights
 @implements IDisposable
 @attribute [AllowAnonymous]
 
@@ -467,6 +468,7 @@
             {
                 // Load CSS on demand
                 await CssLoader.LoadCssAsync(GameCss.WordScape.Path, GameCss.WordScape.Version);
+                _ = AppInsights.TrackPageActivationAsync("WordScape");
 
                 // Initialize address bar management for Android Edge
                 try

--- a/Client/Pages/WordamentGame.razor
+++ b/Client/Pages/WordamentGame.razor
@@ -8,6 +8,7 @@
 @inject DebugHelper DebugHelper
 @inject CssLoaderService CssLoader
 @inject IJSRuntime JSRuntime
+@inject Client.Services.ApplicationInsightsLogger AppInsights
 @implements IDisposable
 @attribute [AllowAnonymous]
 
@@ -542,6 +543,7 @@
         {
             // Load CSS on demand (saves ~44KB on initial load)
             await CssLoader.LoadCssAsync(GameCss.Wordament.Path, GameCss.Wordament.Version);
+            _ = AppInsights.TrackPageActivationAsync("Wordament");
 
             try
             {

--- a/Client/Program.cs
+++ b/Client/Program.cs
@@ -138,6 +138,31 @@ internal class Program
             _ = Task.Run(async () => {
                 await Task.Delay(5000); // [v3] Give SDK more time to initialize on mobile
                 await CollectAndSendStartupInfo();
+
+                // Canonical Site:Loaded event via ApplicationInsightsLogger (includes common props)
+                try
+                {
+                    var appInsights = Host!.Services.GetRequiredService<ApplicationInsightsLogger>();
+                    var jsRuntime   = Host!.Services.GetRequiredService<IJSRuntime>();
+
+                    var ua      = await jsRuntime.InvokeAsync<string>("eval", "navigator.userAgent");
+                    var browser = ua.Contains("Edg/")     ? "Edge"
+                                : ua.Contains("Chrome/")  ? "Chrome"
+                                : ua.Contains("Firefox/") ? "Firefox"
+                                : ua.Contains("Safari/")  ? "Safari" : "Other";
+                    var isMobile = (ua.Contains("Mobile") || ua.Contains("Android") || ua.Contains("iPhone"))
+                                    .ToString().ToLower();
+
+                    await appInsights.TrackSiteLoadedAsync(
+                        buildTime:  BuildInfo.BuildTime,
+                        gitBranch:  BuildInfo.GitBranch,
+                        browser:    browser,
+                        isMobile:   isMobile);
+                }
+                catch (Exception ex)
+                {
+                    Console.WriteLine($"[Telemetry] Site:Loaded event failed: {ex.Message}");
+                }
             });
         }
         catch (Exception ex)

--- a/Client/Services/ApplicationInsightsLogger.cs
+++ b/Client/Services/ApplicationInsightsLogger.cs
@@ -10,6 +10,170 @@ public class ApplicationInsightsLogger
     private readonly IJSRuntime _jsRuntime;
     private bool? _isReady;
 
+    // Common properties cached after first collection
+    private string? _sessionId;
+    private string? _os;
+    private string? _userId;
+    private string? _url;
+    private string? _environment;
+
+    /// <summary>Set the authenticated user's email for inclusion in all subsequent events.</summary>
+    public void SetUserId(string userId) => _userId = userId;
+
+    /// <summary>True once the origin has been resolved and it is a local dev URL.</summary>
+    public bool IsDevEnvironment => _environment == "dev";
+
+    private async Task<Dictionary<string, string>> GetCommonPropertiesAsync()
+    {
+        // Lazy-initialize session ID (one per page-load lifetime)
+        _sessionId ??= Guid.NewGuid().ToString("N")[..12];
+
+        if (_os == null)
+        {
+            try
+            {
+                var ua = await _jsRuntime.InvokeAsync<string>("eval", "navigator.userAgent");
+                _os = DetectOs(ua);
+            }
+            catch
+            {
+                _os = "unknown";
+            }
+        }
+
+        if (_url == null)
+        {
+            try
+            {
+                _url = await _jsRuntime.InvokeAsync<string>("eval", "window.location.origin");
+                _environment = DetectEnvironment(_url);
+            }
+            catch
+            {
+                _url = "unknown";
+                _environment = "unknown";
+            }
+        }
+
+        // Capture the current full URL on every call (page may have navigated)
+        string currentUrl;
+        try { currentUrl = await _jsRuntime.InvokeAsync<string>("eval", "window.location.href"); }
+        catch  { currentUrl = _url; }
+
+        return new Dictionary<string, string>
+        {
+            ["sessionId"]   = _sessionId,
+            ["os"]          = _os,
+            ["userId"]      = _userId ?? "anonymous",
+            ["url"]         = currentUrl,
+            ["environment"] = _environment ?? "unknown",
+        };
+    }
+
+    private static string DetectOs(string ua)
+    {
+        if (ua.Contains("iPhone") || ua.Contains("iPad"))  return "iOS";
+        if (ua.Contains("Android"))                         return "Android";
+        if (ua.Contains("Windows"))                         return "Windows";
+        if (ua.Contains("Macintosh") || ua.Contains("Mac OS X")) return "macOS";
+        if (ua.Contains("Linux"))                           return "Linux";
+        return "Other";
+    }
+
+    private static string DetectEnvironment(string origin)
+    {
+        if (origin.Contains("localhost") || origin.Contains("127.0.0.1")) return "dev";
+        if (origin.Contains(".azurestaticapps.net"))  return "staging";
+        // Add your production hostname(s) here
+        if (origin.Contains("calvinhsia.com"))         return "prod";
+        return "prod"; // Default — assume production for any other deployed origin
+    }
+
+    /// <summary>
+    /// Fired once at app startup from Program.cs after the host is built.
+    /// Captures build metadata and browser capabilities alongside common properties.
+    /// </summary>
+    public async Task TrackSiteLoadedAsync(string buildTime, string gitBranch, string browser, string isMobile)
+    {
+        var props = await GetCommonPropertiesAsync();
+        props["buildTime"]  = buildTime;
+        props["gitBranch"]  = gitBranch;
+        props["browser"]    = browser;
+        props["isMobile"]   = isMobile;
+        await TrackEvent("Site:Loaded", props);
+    }
+
+    /// <summary>Track that a page was activated (first render).</summary>
+    public async Task TrackPageActivationAsync(string pageName, Dictionary<string, string>? extra = null)
+    {
+        var props = await GetCommonPropertiesAsync();
+        props["page"] = pageName;
+        if (extra != null)
+            foreach (var kv in extra) props[kv.Key] = kv.Value;
+
+        await TrackPageView(pageName, props);
+        await TrackEvent($"PageActivation:{pageName}", props);
+    }
+
+    /// <summary>
+    /// Track a login event.
+    /// <paramref name="outcome"/>: "started" | "success" | "failure"
+    /// <paramref name="reason"/>:  human-readable detail, e.g. exception message or "token_ok"
+    /// </summary>
+    public async Task TrackLoginAsync(string outcome, string? reason = null, string? userId = null)
+    {
+        var props = await GetCommonPropertiesAsync();
+        props["outcome"] = outcome;
+        props["reason"]  = reason ?? string.Empty;
+        // Allow the caller to supply the just-resolved userId before SetUserId() is called
+        if (!string.IsNullOrEmpty(userId))
+        {
+            props["userId"] = userId;
+            SetUserId(userId); // persist for all subsequent events in this session
+        }
+        await TrackEvent("Auth:Login", props);
+    }
+
+    /// <summary>
+    /// Track a logout event.
+    /// <paramref name="outcome"/>: "started" | "success" | "failure"
+    /// <paramref name="reason"/>:  human-readable detail or exception message
+    /// </summary>
+    public async Task TrackLogoutAsync(string outcome, string? reason = null)
+    {
+        var props = await GetCommonPropertiesAsync();
+        props["outcome"] = outcome;
+        props["reason"]  = reason ?? string.Empty;
+        await TrackEvent("Auth:Logout", props);
+    }
+
+    /// <summary>Track a PictureQuery filter execution.</summary>
+    public async Task TrackPictureQueryFilterAsync(string filter, string mediaType, int resultCount)
+    {
+        var props = await GetCommonPropertiesAsync();
+        props["filter"]      = filter;
+        props["mediaType"]   = string.IsNullOrEmpty(mediaType) ? "all" : mediaType;
+        props["resultCount"] = resultCount.ToString();
+
+        await TrackEvent("PictureQuery:Filter", props);
+    }
+
+    /// <summary>Track an application error with context.</summary>
+    public async Task TrackErrorAsync(string source, Exception ex, Dictionary<string, string>? extra = null)
+    {
+        var props = await GetCommonPropertiesAsync();
+        props["source"]         = source;
+        props["errorType"]      = ex.GetType().Name;
+        props["errorMessage"]   = ex.Message;
+        if (ex.StackTrace is { } st)
+            props["stackTrace"] = st.Length > 512 ? st[..512] : st;
+        if (extra != null)
+            foreach (var kv in extra) props[kv.Key] = kv.Value;
+
+        await TrackException(ex, props);
+        await TrackEvent("AppError", props);
+    }
+
     public ApplicationInsightsLogger(IJSRuntime jsRuntime)
     {
         _jsRuntime = jsRuntime;
@@ -66,6 +230,11 @@ public class ApplicationInsightsLogger
 
     public async Task TrackEvent(string eventName, Dictionary<string, string>? properties = null)
     {
+        if (IsDevEnvironment)
+        {
+            Console.WriteLine($"[Telemetry suppressed-dev] {eventName}");
+            return;
+        }
         if (!await IsReadyAsync())
         {
             Console.WriteLine($"?? Application Insights not ready - skipping event: {eventName}");
@@ -85,6 +254,11 @@ public class ApplicationInsightsLogger
 
     public async Task TrackTrace(string message, int severityLevel = 1, Dictionary<string, string>? properties = null)
     {
+        if (IsDevEnvironment)
+        {
+            Console.WriteLine($"[Telemetry suppressed-dev] Trace:{message}");
+            return;
+        }
         if (!await IsReadyAsync())
         {
             Console.WriteLine($"?? Application Insights not ready - skipping trace: {message}");
@@ -104,6 +278,11 @@ public class ApplicationInsightsLogger
 
     public async Task TrackException(Exception exception, Dictionary<string, string>? properties = null)
     {
+        if (IsDevEnvironment)
+        {
+            Console.WriteLine($"[Telemetry suppressed-dev] Exception:{exception.GetType().Name}: {exception.Message}");
+            return;
+        }
         if (!await IsReadyAsync())
         {
             Console.WriteLine($"?? Application Insights not ready - skipping exception: {exception.Message}");
@@ -132,6 +311,11 @@ public class ApplicationInsightsLogger
 
     public async Task TrackPageView(string pageName, Dictionary<string, string>? properties = null)
     {
+        if (IsDevEnvironment)
+        {
+            Console.WriteLine($"[Telemetry suppressed-dev] PageView:{pageName}");
+            return;
+        }
         if (!await IsReadyAsync())
         {
             Console.WriteLine($"?? Application Insights not ready - skipping page view: {pageName}");

--- a/Client/Shared/MainLayout.razor
+++ b/Client/Shared/MainLayout.razor
@@ -1,6 +1,9 @@
 ﻿@using Client
+@using Client.Services
+@using Microsoft.AspNetCore.Components.Authorization
 
 @inherits LayoutComponentBase
+@inject ApplicationInsightsLogger AppInsights
 
 <div class="page">
     <div class="sidebar">
@@ -18,3 +21,27 @@
         </article>
     </main>
 </div>
+
+@code {
+    [CascadingParameter] private Task<AuthenticationState>? AuthenticationStateTask { get; set; }
+
+    protected override async Task OnInitializedAsync()
+    {
+        if (AuthenticationStateTask != null)
+        {
+            var authState = await AuthenticationStateTask;
+            var user = authState.User;
+            if (user.Identity?.IsAuthenticated == true)
+            {
+                // Prefer email claim, fall back to name or subject
+                var userId = user.FindFirst("preferred_username")?.Value
+                          ?? user.FindFirst("email")?.Value
+                          ?? user.FindFirst(System.Security.Claims.ClaimTypes.Email)?.Value
+                          ?? user.FindFirst(System.Security.Claims.ClaimTypes.Name)?.Value
+                          ?? user.Identity.Name
+                          ?? "authenticated";
+                AppInsights.SetUserId(userId);
+            }
+        }
+    }
+}

--- a/Client/Shared/TelemetryErrorBoundary.razor
+++ b/Client/Shared/TelemetryErrorBoundary.razor
@@ -1,0 +1,24 @@
+@using Client.Services
+@using Microsoft.AspNetCore.Components.Web
+@inject ApplicationInsightsLogger AppInsights
+@inherits ErrorBoundaryBase
+
+@if (CurrentException is null)
+{
+    @ChildContent
+}
+else
+{
+    <div class="alert alert-danger" role="alert">
+        <strong>An unexpected error occurred.</strong>
+        <p>@CurrentException.Message</p>
+        <button class="btn btn-sm btn-outline-danger" @onclick="Recover">Dismiss</button>
+    </div>
+}
+
+@code {
+    protected override async Task OnErrorAsync(Exception exception)
+    {
+        await AppInsights.TrackErrorAsync("ErrorBoundary", exception);
+    }
+}

--- a/Client/telemetry.md
+++ b/Client/telemetry.md
@@ -1,0 +1,329 @@
+# Telemetry Reference
+
+Events are sent to **Azure Application Insights** via `ApplicationInsightsLogger` (JS SDK interop).  
+All events are **suppressed when running on `localhost`** — a `[Telemetry suppressed-dev]` message
+appears in the browser console instead.
+
+---
+
+## Common Properties
+
+Every event includes these dimensions:
+
+| Property | Description | Example |
+|---|---|---|
+| `sessionId` | Random 12-char hex, one per page-load lifetime | `a3f9c12d8b04` |
+| `os` | Parsed from `navigator.userAgent` | `Windows`, `iOS`, `Android`, `macOS`, `Linux` |
+| `userId` | Authenticated user email; `anonymous` until login resolves | `calvin_hsia@live.com` |
+| `url` | `window.location.href` at the moment the event fires | `https://calvinhsia.com/fish` |
+| `environment` | Derived from `window.location.origin` | `dev`, `staging`, `prod` |
+
+### Environment label rules (`DetectEnvironment`)
+| Origin contains | Label |
+|---|---|
+| `localhost` or `127.0.0.1` | `dev` (events suppressed) |
+| `.azurestaticapps.net` | `staging` |
+| `calvinhsia.com` | `prod` |
+| anything else | `prod` |
+
+---
+
+## Event Catalog
+
+### `Site:Loaded`
+Fired **once per session** from `Program.cs` ~5 seconds after the Blazor WASM host starts
+(delay allows the AI SDK to finish loading from CDN).
+
+| Extra property | Description |
+|---|---|
+| `buildTime` | `BuildInfo.BuildTime` — when the DLL was compiled |
+| `gitBranch` | `BuildInfo.GitBranch` — active git branch at build time |
+| `browser` | `Edge`, `Chrome`, `Firefox`, `Safari`, `Other` |
+| `isMobile` | `true` / `false` |
+
+---
+
+### `PageActivation:<page>`  +  PageView `<page>`
+Fired on **first render** of each page component (`OnAfterRenderAsync(firstRender)`).
+
+Pages instrumented: `Bounce`, `Fish`, `Ant`, `Life`, `Mandelbrot`, `Snake`, `Tetris`,
+`Minesweeper`, `Cartoon`, `FreeCell`, `Hearts`, `Solitaire`, `Wordament`, `WordScape`,
+`Logo`, `PictureQuery`.
+
+| Extra property | Description |
+|---|---|
+| `page` | Page name, e.g. `Fish` |
+
+---
+
+### `Auth:Login`
+Fired at every stage of the MSAL login flow.
+
+| `outcome` value | `reason` value | Where |
+|---|---|---|
+| `initiated` | `user_clicked_sign_in` | User clicks Sign In on `/LoginPage` |
+| `started` | `action=login` | `Authentication.razor` loaded for `login` action |
+| `started` | `action=login-callback` | MSAL redirect callback arrives |
+| `success` | `token_ok` | Access token retrieved successfully |
+| `success` | `auth_state_ok` | Authenticated via `AuthenticationState` fallback |
+| `failure` | `no_token_after_retries` | All 3 retry attempts failed |
+| `failure` | `AccessTokenNotAvailable: …` | `AccessTokenNotAvailableException` thrown |
+| `failure` | exception message | Unexpected error in auth check |
+
+On **success**, `userId` is also set from the resolved `preferred_username` / `ClaimTypes.Name`
+claim and stored for the rest of the session.
+
+---
+
+### `Auth:Logout`
+Fired at every stage of the MSAL logout flow.
+
+| `outcome` value | `reason` value | Where |
+|---|---|---|
+| `started` | `action=logout` | `Authentication.razor` loaded for `logout` |
+| `started` | `action=logout-callback` | Logout callback arrives |
+| `success` | `logged-out` | `logged-out` action received |
+| `success` | `storage_cleared` | `ForceLogout` cleared localStorage/sessionStorage |
+| `failure` | exception message | Error during `ForceLogout` |
+
+---
+
+### `PictureQuery:Filter`
+Fired every time the user executes a query on the `/PictureQuery` page.
+
+| Extra property | Description |
+|---|---|
+| `filter` | The notes/filename filter text entered |
+| `mediaType` | `photo`, `video`, or `all` |
+| `resultCount` | Number of pictures returned |
+
+---
+
+### `AppError`  +  Exception
+Fired by `TelemetryErrorBoundary` (wraps the entire `<Router>`) for any unhandled
+component-tree exception, and by `PictureQuery` initialization errors.
+
+| Extra property | Description |
+|---|---|
+| `source` | C# location, e.g. `ErrorBoundary`, `PictureQuery.OnInitializedAsync` |
+| `errorType` | Exception class name |
+| `errorMessage` | `Exception.Message` |
+| `stackTrace` | First 512 chars of stack trace |
+
+---
+
+### Legacy startup events (via old `TelemetryService`)
+These exist alongside `Site:Loaded` and are sent via the older JS interop path:
+
+| Event name | Description |
+|---|---|
+| `ApplicationStartup` | Host/environment info at startup |
+| `ClientEnvironment` | Detailed browser capabilities (screen, viewport, CPU, memory, connection) |
+| `StartupComplete` | Debug mode + build branch after all initialization |
+
+---
+
+## Sample KQL Queries
+
+> Paste these into **Azure Portal → Application Insights → Logs**.
+
+---
+
+### Page usage — visits per page
+
+```kql
+customEvents
+| where name startswith "PageActivation:"
+| summarize visits = count()
+    by page     = tostring(customDimensions.page),
+       env      = tostring(customDimensions.environment)
+| order by visits desc
+```
+
+---
+
+### Page usage over time (daily trend)
+
+```kql
+customEvents
+| where name startswith "PageActivation:"
+| summarize visits = count()
+    by page = tostring(customDimensions.page),
+       day  = startofday(timestamp)
+| order by day desc, visits desc
+```
+
+---
+
+### Unique users per page (last 30 days)
+
+```kql
+customEvents
+| where name startswith "PageActivation:"
+    and timestamp > ago(30d)
+| summarize unique_users = dcount(tostring(customDimensions.userId))
+    by page = tostring(customDimensions.page)
+| order by unique_users desc
+```
+
+---
+
+### OS/device breakdown
+
+```kql
+customEvents
+| where name == "Site:Loaded"
+| summarize sessions = count()
+    by os       = tostring(customDimensions.os),
+       browser  = tostring(customDimensions.browser),
+       isMobile = tostring(customDimensions.isMobile)
+| order by sessions desc
+```
+
+---
+
+### Deployments — site loads by build + branch
+
+```kql
+customEvents
+| where name == "Site:Loaded"
+| summarize first_seen = min(timestamp), loads = count()
+    by gitBranch = tostring(customDimensions.gitBranch),
+       buildTime = tostring(customDimensions.buildTime)
+| order by first_seen desc
+```
+
+---
+
+### Login funnel
+
+```kql
+customEvents
+| where name == "Auth:Login"
+| summarize count()
+    by outcome = tostring(customDimensions.outcome),
+       reason  = tostring(customDimensions.reason)
+| order by count_ desc
+```
+
+---
+
+### Login failures — detail
+
+```kql
+customEvents
+| where name == "Auth:Login"
+    and tostring(customDimensions.outcome) == "failure"
+| project timestamp,
+          reason      = tostring(customDimensions.reason),
+          userId      = tostring(customDimensions.userId),
+          os          = tostring(customDimensions.os),
+          browser     = tostring(customDimensions.browser),
+          environment = tostring(customDimensions.environment)
+| order by timestamp desc
+```
+
+---
+
+### Logout success vs failure
+
+```kql
+customEvents
+| where name == "Auth:Logout"
+| summarize count() by outcome = tostring(customDimensions.outcome)
+```
+
+---
+
+### PictureQuery — most used filters
+
+```kql
+customEvents
+| where name == "PictureQuery:Filter"
+| summarize queries    = count(),
+            avg_results = avg(toint(customDimensions.resultCount))
+    by filter    = tostring(customDimensions.filter),
+       mediaType = tostring(customDimensions.mediaType)
+| order by queries desc
+```
+
+---
+
+### PictureQuery — filters with zero results
+
+```kql
+customEvents
+| where name == "PictureQuery:Filter"
+    and toint(customDimensions.resultCount) == 0
+| project timestamp,
+          filter    = tostring(customDimensions.filter),
+          mediaType = tostring(customDimensions.mediaType),
+          userId    = tostring(customDimensions.userId)
+| order by timestamp desc
+```
+
+---
+
+### Application errors — recent
+
+```kql
+customEvents
+| where name == "AppError"
+| project timestamp,
+          source       = tostring(customDimensions.source),
+          errorType    = tostring(customDimensions.errorType),
+          errorMessage = tostring(customDimensions.errorMessage),
+          userId       = tostring(customDimensions.userId),
+          url          = tostring(customDimensions.url)
+| order by timestamp desc
+```
+
+---
+
+### Error rate over time
+
+```kql
+customEvents
+| where name == "AppError"
+| summarize errors = count() by hour = startofhour(timestamp)
+| order by hour desc
+```
+
+---
+
+### Sessions per day (unique sessionIds)
+
+```kql
+customEvents
+| summarize sessions = dcount(tostring(customDimensions.sessionId))
+    by day = startofday(timestamp)
+| order by day desc
+```
+
+---
+
+### Active users — last 7 days
+
+```kql
+customEvents
+| where timestamp > ago(7d)
+    and tostring(customDimensions.userId) != "anonymous"
+| summarize days_active = dcount(startofday(timestamp))
+    by userId = tostring(customDimensions.userId)
+| order by days_active desc
+```
+
+---
+
+## Retention & Cost
+
+| Item | Value |
+|---|---|
+| Default retention | 90 days |
+| Maximum retention | 730 days (2 years) — set in portal under *Usage and estimated costs* |
+| Free ingestion | 5 GB / month |
+| Overage | ~$2.30 / GB |
+| Local dev | **All events suppressed** (`localhost`/`127.0.0.1`) |
+
+Set a **daily ingestion cap** in the portal to prevent surprise bills:  
+*Application Insights → Configure → Usage and estimated costs → Daily cap*


### PR DESCRIPTION
Integrated ApplicationInsightsLogger across all Blazor WASM pages and authentication flows to track page activations, login/logout events, PictureQuery usage, and unhandled errors. Wrapped the main Router in a TelemetryErrorBoundary for error reporting. Suppressed telemetry on localhost. Added telemetry.md with event catalog and KQL queries. User IDs are now set in telemetry after authentication. Site:Loaded event is fired at startup with build and environment info.