### PR TITLE
Refactor shared folder logic to new PictureService

### DIFF
--- a/Client/Pages/PictureQuery.razor.cs
+++ b/Client/Pages/PictureQuery.razor.cs
@@ -20,6 +20,7 @@ public partial class PictureQuery : IDisposable
     [Inject] private IAccessTokenProvider TokenProvider { get; set; } = null!;
     [Inject] private AuthTokenHelper AuthToken { get; set; } = null!;
     [Inject] private AlbumService AlbumService { get; set; } = null!;
+    [Inject] private Client.Services.PictureService PictureService { get; set; } = null!;
     [Inject] private Client.Services.ApplicationInsightsLogger AppInsights { get; set; } = null!;
 
     // Parameters
@@ -178,7 +179,7 @@ public partial class PictureQuery : IDisposable
                 if (isGuestUser)
                 {
                     Console.WriteLine("Guest user detected — initializing shared drive context...");
-                    var sharedError = await AlbumService.InitializeSharedContextAsync(_httpClient!);
+                    var sharedError = await PictureService.InitializeSharedContextAsync(_httpClient!);
                     if (sharedError != null)
                     {
                         statusMessage = $"⚠️ {sharedError}";
@@ -186,7 +187,7 @@ public partial class PictureQuery : IDisposable
                     }
                     else
                     {
-                        Console.WriteLine($"Shared context ready: driveId={AlbumService.SharedContext!.DriveId}");
+                        Console.WriteLine($"Shared context ready: driveId={PictureService.SharedContext!.DriveId}");
                     }
                 }
                 else

--- a/Client/Program.cs
+++ b/Client/Program.cs
@@ -65,6 +65,9 @@ internal class Program
         // Add authentication helper for centralized token handling
         builder.Services.AddScoped<AuthTokenHelper>();
         
+        // Add picture service for shared OneDrive folder context
+        builder.Services.AddScoped<Client.Services.PictureService>();
+
         // Add album service for OneDrive album operations
         builder.Services.AddScoped<AlbumService>();
         

--- a/Client/Services/AlbumService.cs
+++ b/Client/Services/AlbumService.cs
@@ -6,92 +6,24 @@ using System.Text.Json;
 using System.Threading;
 using System.Threading.Tasks;
 using Client.Shared;
+using Client.Services;
 
 namespace WordScapeBlazorWasm.Services
 {
-    /// <summary>
-    /// Holds remote drive context for accessing a shared OneDrive folder.
-    /// </summary>
-    public record SharedDriveContext(string DriveId, string RootItemId);
-
     /// <summary>
     /// Service for managing OneDrive album operations via Microsoft Graph API
     /// </summary>
     public class AlbumService
     {
-        private const string SharedFolderName = "OldPictures";
+        private readonly PictureService _pictureService;
 
-        /// <summary>
-        /// When non-null, all file access is routed through this shared drive context.
-        /// </summary>
-        public SharedDriveContext? SharedContext { get; private set; }
-
-        /// <summary>
-        /// Call once after authentication to set up the shared context when the signed-in user
-        /// is not the owner. Searches sharedWithMe for a folder named "OldPictures".
-        /// Returns an error message if the folder is not found, or null on success.
-        /// </summary>
-        public async Task<string?> InitializeSharedContextAsync(HttpClient httpClient)
+        public AlbumService(PictureService pictureService)
         {
-            SharedContext = null;
-            try
-            {
-                var response = await httpClient.GetAsync($"{MSGraphEndPoint}me/drive/sharedWithMe");
-                if (!response.IsSuccessStatusCode)
-                {
-                    return $"Could not access sharedWithMe: {response.StatusCode}";
-                }
-
-                var json = await response.Content.ReadAsStringAsync();
-                using var doc = JsonDocument.Parse(json);
-
-                if (!doc.RootElement.TryGetProperty("value", out var valueArray))
-                    return $"Shared folder '{SharedFolderName}' not found (no value array).";
-
-                Console.WriteLine($"[AlbumService] sharedWithMe returned {valueArray.GetArrayLength()} item(s)");
-                foreach (var item in valueArray.EnumerateArray())
-                {
-                    var topName = item.TryGetProperty("name", out var nameEl) ? nameEl.GetString() : "(no name)";
-                    item.TryGetProperty("remoteItem", out var remoteItem);
-                    var remoteNameStr = remoteItem.ValueKind == JsonValueKind.Object && remoteItem.TryGetProperty("name", out var rn) ? rn.GetString() : null;
-                    Console.WriteLine($"[AlbumService] sharedWithMe item: name='{topName}' remoteName='{remoteNameStr}' hasRemoteItem={remoteItem.ValueKind == JsonValueKind.Object}");
-
-                    // Match on top-level name OR remoteItem.name (read-only shares may differ)
-                    bool nameMatch = topName == SharedFolderName || remoteNameStr == SharedFolderName;
-                    if (nameMatch && remoteItem.ValueKind == JsonValueKind.Object)
-                    {
-                        var remoteItemId = remoteItem.GetProperty("id").GetString()!;
-
-                        // driveId can be at remoteItem.parentReference.driveId or remoteItem.parentReference.driveId
-                        string? remoteDriveId = null;
-                        if (remoteItem.TryGetProperty("parentReference", out var parentRef) &&
-                            parentRef.TryGetProperty("driveId", out var driveIdEl))
-                        {
-                            remoteDriveId = driveIdEl.GetString();
-                        }
-
-                        if (string.IsNullOrEmpty(remoteDriveId))
-                        {
-                            Console.WriteLine($"[AlbumService] WARNING: remoteItem found but driveId missing. remoteItem JSON: {remoteItem}");
-                            return $"Shared folder '{SharedFolderName}' found but driveId is missing in remoteItem.parentReference.";
-                        }
-
-                        SharedContext = new SharedDriveContext(remoteDriveId, remoteItemId);
-                        Console.WriteLine($"[AlbumService] Shared context initialized: driveId={remoteDriveId} itemId={remoteItemId}");
-                        return null; // success
-                    }
-                }
-
-                // Log full JSON for diagnosis when not found
-                Console.WriteLine($"[AlbumService] '{SharedFolderName}' not found. Full sharedWithMe JSON: {json}");
-                return $"Shared folder '{SharedFolderName}' not found in sharedWithMe.";
-            }
-            catch (Exception ex)
-            {
-                Console.WriteLine($"[AlbumService] Error initializing shared context: {ex.Message}");
-                return $"Error accessing shared folder: {ex.Message}";
-            }
+            _pictureService = pictureService;
         }
+
+        private SharedDriveContext? SharedContext => _pictureService.SharedContext;
+
         private const string MSGraphEndPoint = "https://graph.microsoft.com/v1.0/";
 
         /// <summary>

--- a/Client/Services/PictureService.cs
+++ b/Client/Services/PictureService.cs
@@ -1,0 +1,173 @@
+using System.Text.Json;
+using WordScapeBlazorWasm.Services;
+
+namespace Client.Services;
+
+/// <summary>
+/// Holds remote drive context for accessing a shared OneDrive folder.
+/// </summary>
+public record SharedDriveContext(string DriveId, string RootItemId);
+
+/// <summary>
+/// Service for picture/OneDrive shared-folder concerns: resolving the shared
+/// drive context for guest users.
+/// </summary>
+public class PictureService
+{
+    private const string SharedFolderName = "OldPictures";
+    private const string MSGraphEndPoint = "https://graph.microsoft.com/v1.0/";
+
+    /// <summary>
+    /// The permanent driveId and itemId of the owner's OldPictures folder.
+    /// These are stable OneDrive identifiers — they never change unless the
+    /// folder is deleted and recreated. Used as a fallback when sharedWithMe
+    /// doesn't list the folder (e.g. recipient has never clicked the share link).
+    /// </summary>
+    private static readonly SharedDriveContext OwnerFolderContext = new(
+        DriveId: "b!83dYf68A3UqwIndPKXO86ksbNT9FWcZDpoHwpxsFSmAvmEFhctIgTLOZOz0qfQS1",
+        RootItemId: "D69F3552CEFC21!s99c97fcc716e491f80d1762f6db950d0");
+
+    private readonly TelemetryService _telemetry;
+
+    public PictureService(TelemetryService telemetry)
+    {
+        _telemetry = telemetry;
+    }
+
+    /// <summary>
+    /// When non-null, all file access is routed through this shared drive context.
+    /// </summary>
+    public SharedDriveContext? SharedContext { get; private set; }
+
+    /// <summary>
+    /// Call once after authentication to set up the shared context when the signed-in
+    /// user is not the owner. First tries sharedWithMe; if not found there, falls back
+    /// to the hardcoded owner folder context (works even before recipient opens the share link).
+    /// Returns an error message if access is denied, or null on success.
+    /// </summary>
+    public async Task<string?> InitializeSharedContextAsync(HttpClient httpClient)
+    {
+        SharedContext = null;
+        try
+        {
+            // --- Primary: search sharedWithMe ---
+            var sharedWithMeError = await TryInitFromSharedWithMeAsync(httpClient);
+            if (SharedContext != null)
+                return null; // success
+
+            // --- Fallback: use the stable owner folder IDs directly.
+            // sharedWithMe only lists folders the recipient has opened via a share link at
+            // least once. The owner's driveId/itemId are permanent and never change, so we
+            // can use them directly without requiring any prior interaction.
+            await _telemetry.TrackEventAsync("SharedContext.FallbackToOwnerIds");
+            var verified = await VerifyOwnerContextAccessAsync(httpClient);
+            if (verified)
+            {
+                SharedContext = OwnerFolderContext;
+                await _telemetry.TrackEventAsync("SharedContext.Initialized",
+                    new Dictionary<string, string> { ["source"] = "ownerIds" });
+                return null;
+            }
+
+            return sharedWithMeError;
+        }
+        catch (Exception ex)
+        {
+            await _telemetry.TrackExceptionAsync(ex,
+                new Dictionary<string, string> { ["context"] = "InitializeSharedContextAsync" });
+            return $"Error accessing shared folder: {ex.Message}";
+        }
+    }
+
+    // -------------------------------------------------------------------------
+
+    private async Task<string?> TryInitFromSharedWithMeAsync(HttpClient httpClient)
+    {
+        var response = await httpClient.GetAsync($"{MSGraphEndPoint}me/drive/sharedWithMe");
+        if (!response.IsSuccessStatusCode)
+        {
+            var msg = $"Could not access sharedWithMe: {response.StatusCode}";
+            await _telemetry.TrackEventAsync("SharedContext.AccessFailed",
+                new Dictionary<string, string> { ["statusCode"] = response.StatusCode.ToString() });
+            return msg;
+        }
+
+        var json = await response.Content.ReadAsStringAsync();
+        using var doc = JsonDocument.Parse(json);
+
+        if (!doc.RootElement.TryGetProperty("value", out var valueArray))
+        {
+            await _telemetry.TrackEventAsync("SharedContext.NoValueArray");
+            return $"Shared folder '{SharedFolderName}' not found (no value array).";
+        }
+
+        await _telemetry.TrackEventAsync("SharedContext.Searching",
+            new Dictionary<string, string> { ["itemCount"] = valueArray.GetArrayLength().ToString() });
+
+        foreach (var item in valueArray.EnumerateArray())
+        {
+            var topName = item.TryGetProperty("name", out var nameEl) ? nameEl.GetString() : null;
+            item.TryGetProperty("remoteItem", out var remoteItem);
+            var remoteName = remoteItem.ValueKind == JsonValueKind.Object &&
+                             remoteItem.TryGetProperty("name", out var rn) ? rn.GetString() : null;
+
+            bool nameMatch = topName == SharedFolderName || remoteName == SharedFolderName;
+            if (nameMatch && remoteItem.ValueKind == JsonValueKind.Object)
+            {
+                var remoteItemId = remoteItem.GetProperty("id").GetString()!;
+
+                string? remoteDriveId = null;
+                if (remoteItem.TryGetProperty("parentReference", out var parentRef) &&
+                    parentRef.TryGetProperty("driveId", out var driveIdEl))
+                {
+                    remoteDriveId = driveIdEl.GetString();
+                }
+
+                if (string.IsNullOrEmpty(remoteDriveId))
+                {
+                    await _telemetry.TrackEventAsync("SharedContext.MissingDriveId",
+                        new Dictionary<string, string> { ["itemId"] = remoteItemId });
+                    return $"Shared folder '{SharedFolderName}' found but driveId is missing in remoteItem.parentReference.";
+                }
+
+                SharedContext = new SharedDriveContext(remoteDriveId, remoteItemId);
+                await _telemetry.TrackEventAsync("SharedContext.Initialized",
+                    new Dictionary<string, string> { ["source"] = "sharedWithMe", ["driveId"] = remoteDriveId, ["itemId"] = remoteItemId });
+                return null;
+            }
+        }
+
+        await _telemetry.TrackEventAsync("SharedContext.FolderNotFound",
+            new Dictionary<string, string>
+            {
+                ["sharedWithMeJson"] = json.Length > 2000 ? json[..2000] : json
+            });
+        return $"Shared folder '{SharedFolderName}' not found in sharedWithMe.";
+    }
+
+    /// <summary>
+    /// Verifies that the current user can actually read the owner's OldPictures folder
+    /// using the hardcoded stable IDs. Returns true if accessible.
+    /// </summary>
+    private async Task<bool> VerifyOwnerContextAccessAsync(HttpClient httpClient)
+    {
+        try
+        {
+            var url = $"{MSGraphEndPoint}drives/{OwnerFolderContext.DriveId}/items/{OwnerFolderContext.RootItemId}?$select=id,name";
+            var response = await httpClient.GetAsync(url);
+            if (response.IsSuccessStatusCode)
+                return true;
+
+            var body = await response.Content.ReadAsStringAsync();
+            await _telemetry.TrackEventAsync("SharedContext.OwnerIdsFailed",
+                new Dictionary<string, string> { ["statusCode"] = response.StatusCode.ToString(), ["body"] = body[..Math.Min(500, body.Length)] });
+            return false;
+        }
+        catch (Exception ex)
+        {
+            await _telemetry.TrackExceptionAsync(ex,
+                new Dictionary<string, string> { ["context"] = "VerifyOwnerContextAccessAsync" });
+            return false;
+        }
+    }
+}

--- a/TestProject1/TestAlbumService.cs
+++ b/TestProject1/TestAlbumService.cs
@@ -8,6 +8,8 @@ using System.Threading.Tasks;
 using WordScapeBlazorWasm.Services;
 using System.Text.Json;
 using Client.Shared;
+using Client.Services;
+using Microsoft.JSInterop;
 
 namespace TestProject1
 {
@@ -25,7 +27,10 @@ namespace TestProject1
         [TestInitialize]
         public void TestInitialize()
         {
-            _albumService = new AlbumService();
+            var mockJsRuntime = new Mock<Microsoft.JSInterop.IJSRuntime>();
+            var telemetryService = new TelemetryService(mockJsRuntime.Object);
+            var pictureService = new PictureService(telemetryService);
+            _albumService = new AlbumService(pictureService);
             _mockHttpMessageHandler = new Mock<HttpMessageHandler>();
             _httpClient = new HttpClient(_mockHttpMessageHandler.Object);
         }

--- a/docs/AddingGuestUsers.md
+++ b/docs/AddingGuestUsers.md
@@ -1,0 +1,61 @@
+# Adding Guest Users to OldPictures
+
+## How it works
+
+Guest users see photos from the owner's (`Calvin_Hsia@live.com`) **OldPictures** OneDrive folder.
+The app identifies a guest as anyone who logs in with an email other than `OwnerEmail` in `PictureQuery.razor.cs`.
+
+When a guest logs in, `PictureService.InitializeSharedContextAsync` resolves the shared folder in two steps:
+
+1. **Primary** — searches `sharedWithMe` (fast, works after the guest has clicked a share link at least once)
+2. **Fallback** — calls `GET /drives/{driveId}/items/{itemId}` using the stable `OwnerFolderContext` constants in `PictureService.cs` (works immediately, no link click required)
+
+So **guests do not need to click a share link** before using the app — permission granted in OneDrive is sufficient.
+
+## Steps to add a new guest
+
+### 1. Share the folder in OneDrive
+
+1. Go to [OneDrive](https://onedrive.live.com) and sign in as `Calvin_Hsia@live.com`
+2. Right-click **OldPictures** → **Share**
+3. Enter the guest's Microsoft account email
+4. Set permission to **Can view** (or **Can edit** if appropriate)
+5. Click **Send** (or **Copy link** — the guest does not need to click it for the app to work)
+
+### 2. No code changes needed
+
+The `OwnerFolderContext` constants in `PictureService.cs` are tied to the **OldPictures folder itself**, not to individual guests:
+
+```csharp
+private static readonly SharedDriveContext OwnerFolderContext = new(
+    DriveId: "b!83dYf68A3UqwIndPKXO86ksbNT9FWcZDpoHwpxsFSmAvmEFhctIgTLOZOz0qfQS1",
+    RootItemId: "D69F3552CEFC21!s99c97fcc716e491f80d1762f6db950d0");
+```
+
+Any Microsoft account that has been granted permission to **OldPictures** in OneDrive will automatically get access — no `appsettings.json` changes, no redeployment.
+
+### 3. Verify access (optional)
+
+Have the guest navigate to the app and sign in. The browser console (F12) will show one of:
+
+| Log message | Meaning |
+|---|---|
+| `SharedContext.Initialized` with `source=sharedWithMe` | Found via sharedWithMe (guest has opened a link before) |
+| `SharedContext.Initialized` with `source=ownerIds` | Found via fallback (works without clicking any link) |
+| `SharedContext.OwnerIdsFailed` with `statusCode=403` | Guest's account was not granted permission in OneDrive |
+
+## If OldPictures is ever recreated
+
+The `OwnerFolderContext` constants would need updating. To find the new values:
+
+1. Log in as the owner and navigate to the PictureQuery page
+2. The `/me` response is logged to the console — it contains the driveId
+3. Or call `GET https://graph.microsoft.com/v1.0/me/drive/root:/OldPictures?$select=id,parentReference` in [Graph Explorer](https://developer.microsoft.com/en-us/graph/graph-explorer)
+4. Update `DriveId` (from `parentReference.driveId`) and `RootItemId` (from `id`) in `PictureService.cs`
+
+## Current guests
+
+| Name | Email | Permission |
+|---|---|---|
+| Pamela Hsia | pamelahsia@hotmail.com | Can view |
+| Calvin Hsia_Test | calvin_hsia_test@outlook.com | Can edit |


### PR DESCRIPTION
Move shared OneDrive context logic from AlbumService to PictureService, centralizing guest access and fallback handling. Update DI, usages, and tests accordingly. Add AddingGuestUsers.md to document guest access and folder sharing process.