### PR TITLE
Update OwnerFolderContext DriveId and JS zoom patch guard

### DIFF
--- a/Client/Pages/PictureQuery.razor
+++ b/Client/Pages/PictureQuery.razor
@@ -615,14 +615,16 @@
         };
     }
 
-    // Reset zoom when a new image is set
-    const _origSetImageSrc = window.setImageSrc;
-    window.setImageSrc = async (id, stream) => {
-        await _origSetImageSrc(id, stream);
-        if (id === 'imageMain') {
-            const img = document.getElementById('imageMain');
-            if (img) { img.style.transform = ''; img._zoomInited = false; }
-            setTimeout(() => window.initLightboxZoom && window.initLightboxZoom(), 50);
-        }
-    };
+    // Reset zoom when a new image is set — guard so this only runs once per page load
+    if (!window._origSetImageSrc) {
+        window._origSetImageSrc = window.setImageSrc;
+        window.setImageSrc = async (id, stream) => {
+            await window._origSetImageSrc(id, stream);
+            if (id === 'imageMain') {
+                const img = document.getElementById('imageMain');
+                if (img) { img.style.transform = ''; img._zoomInited = false; }
+                setTimeout(() => window.initLightboxZoom && window.initLightboxZoom(), 50);
+            }
+        };
+    }
 </script>

--- a/Client/Services/PictureService.cs
+++ b/Client/Services/PictureService.cs
@@ -24,7 +24,7 @@ public class PictureService
     /// doesn't list the folder (e.g. recipient has never clicked the share link).
     /// </summary>
     private static readonly SharedDriveContext OwnerFolderContext = new(
-        DriveId: "b!83dYf68A3UqwIndPKXO86ksbNT9FWcZDpoHwpxsFSmAvmEFhctIgTLOZOz0qfQS1",
+        DriveId: "00d69f3552cefc21",
         RootItemId: "D69F3552CEFC21!s99c97fcc716e491f80d1762f6db950d0");
 
     private readonly TelemetryService _telemetry;

--- a/docs/AddingGuestUsers.md
+++ b/docs/AddingGuestUsers.md
@@ -28,7 +28,7 @@ The `OwnerFolderContext` constants in `PictureService.cs` are tied to the **OldP
 
 ```csharp
 private static readonly SharedDriveContext OwnerFolderContext = new(
-    DriveId: "b!83dYf68A3UqwIndPKXO86ksbNT9FWcZDpoHwpxsFSmAvmEFhctIgTLOZOz0qfQS1",
+    DriveId: "00d69f3552cefc21",
     RootItemId: "D69F3552CEFC21!s99c97fcc716e491f80d1762f6db950d0");
 ```
 


### PR DESCRIPTION
- Change OwnerFolderContext DriveId to new value in PictureService.cs and update docs for consistency
- Guard JS patch in PictureQuery.razor to only wrap setImageSrc once per page load, preventing multiple wrappings