### PR TITLE
Update CSP to allow media-src from blob, self, and https

### DIFF
--- a/Client/staticwebapp.config.json
+++ b/Client/staticwebapp.config.json
@@ -86,7 +86,7 @@
     }
   },
   "globalHeaders": {
-    "content-security-policy": "default-src 'self' https: 'unsafe-eval' 'unsafe-inline'; object-src 'none'; img-src blob: data: 'self' https:; script-src 'self' 'unsafe-inline' 'unsafe-eval' https://login.microsoftonline.com https://alcdn.msauth.net https://alcdn.msftauth.net; connect-src 'self' https: wss:; frame-src 'self' https://login.microsoftonline.com; frame-ancestors 'self'"
+    "content-security-policy": "default-src 'self' https: 'unsafe-eval' 'unsafe-inline'; object-src 'none'; img-src blob: data: 'self' https:; media-src blob: 'self' https:; script-src 'self' 'unsafe-inline' 'unsafe-eval' https://login.microsoftonline.com https://alcdn.msauth.net https://alcdn.msftauth.net; connect-src 'self' https: wss:; frame-src 'self' https://login.microsoftonline.com; frame-ancestors 'self'"
   },
   "mimeTypes": {
     ".json": "text/json"


### PR DESCRIPTION
Expanded content security policy in staticwebapp.config.json to permit media resources (audio/video) from blob URLs, the same origin, and HTTPS sources. This enables proper loading of media assets in the app.