### PR TITLE
Refactor auth: MSAL roles, guest allowlist, UI updates

### DIFF
--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -9,6 +9,40 @@ This is a Blazor WebAssembly application with multiple interactive games and fea
 - **Bounce**: Physics simulation with bouncing balls
 - **Fish**: Fish vs Sharks cellular automata simulation
 
+## Authentication Architecture
+
+### Two-System Reality
+The app uses **MSAL directly** for login (not SWA's `/.auth/login` flow). This means:
+- SWA's edge layer always sees users as `anonymous` — `allowedRoles` in `staticwebapp.config.json` cannot gate API calls
+- `x-ms-client-principal` header is **never** injected (only works with `/.auth/login`)
+- SWA replaces the `Authorization` header with an internal Kudu token before forwarding to Functions
+
+### User Roles (Client-Side)
+`UserContextService` (singleton) tracks three roles resolved after the Graph `/me` call:
+- **Owner** — `calvin_hsia@live.com` (hardcoded constant `OwnerEmail` in `PictureQuery.razor.cs`)
+- **Guest** — any email in the `ALLOWED_EMAILS` app setting
+- **Anonymous** — not signed in or email not in allowlist
+
+`NavMenu.razor` gates "My Stuff" on `UserContext.IsAuthenticated`. Owner vs Guest is shown in the label.
+
+### Adding a New Guest User (No Redeploy Required)
+1. Azure Portal → Function App → **Configuration → Application settings**
+2. Edit `ALLOWED_EMAILS` — semicolon-separated list, e.g.:  
+   `calvin_hsia@live.com;calvin_hsia_test@outlook.com;pamelahsia@hotmail.com;newguest@example.com`
+3. Save & restart — takes effect immediately, no code change or deployment needed
+
+### API Authorization (`SwaAuthHelper.cs`)
+- `#if DEBUG` — always passes (F5 works without any setup)
+- Checks `x-ms-client-principal` first (future-proof if ever switching to `/.auth/login`)
+- Falls back to `&u=<email>` query param sent by the client (SWA doesn't strip query params)
+- `GetAllowedEmails()` reads `ALLOWED_EMAILS` env var at runtime; falls back to hardcoded set for local dev
+- **Security note:** `&u=` is unverified — anyone knowing an allowed email can call the API. Acceptable for read-only photo queries.
+
+### Why Not Switch to SWA's `/.auth/login`?
+- F5 debugging breaks (SWA auth endpoints don't exist on localhost)
+- PR preview environments get random domains; AAD app registrations don't support wildcards for personal accounts (`consumers` authority)
+- Graph API calls (OneDrive, `/me`) would require On-Behalf-Of flow — significant rewrite
+
 ## Build Requirements
 
 ### Required SDK and Workloads

--- a/Api/SwaAuthHelper.cs
+++ b/Api/SwaAuthHelper.cs
@@ -13,13 +13,31 @@ namespace Api
         private static readonly HashSet<string> AllowedRoles =
             new(StringComparer.OrdinalIgnoreCase) { "owner", "pictureQuery" };
 
-        private static readonly HashSet<string> AllowedEmails =
-            new(StringComparer.OrdinalIgnoreCase)
+        /// <summary>
+        /// Returns the allowed-emails set. Read from the ALLOWED_EMAILS app setting
+        /// (semicolon-separated) so users can be added/removed in the Azure portal
+        /// without redeployment. Falls back to a hardcoded set for local dev.
+        /// </summary>
+        private static HashSet<string> GetAllowedEmails()
+        {
+            var envVal = Environment.GetEnvironmentVariable("ALLOWED_EMAILS");
+            if (!string.IsNullOrWhiteSpace(envVal))
+            {
+                var emails = envVal.Split(';', StringSplitOptions.RemoveEmptyEntries | StringSplitOptions.TrimEntries);
+                var hashSet= new HashSet<string>(emails, StringComparer.OrdinalIgnoreCase)
+                {
+                    "calvin_hsia@live.com" // Ensure my email is always allowed, even if not in portal setting, so works in az preview envs
+                };
+                return hashSet;
+            }
+            // Fallback for local dev (F5) — no portal app setting needed
+            return new HashSet<string>(StringComparer.OrdinalIgnoreCase)
             {
                 "calvin_hsia@live.com",
                 "calvin_hsia_test@outlook.com",
                 "pamelahsia@hotmail.com"
             };
+        }
 
         public static bool IsAuthorized(HttpRequestData req, ILogger logger)
         {
@@ -47,7 +65,8 @@ namespace Api
             if (!string.IsNullOrEmpty(userEmail))
             {
                 logger.LogInformation("[SwaAuth] &u= param: '{email}'", userEmail);
-                if (AllowedEmails.Contains(userEmail))
+                var allowedEmails = GetAllowedEmails();
+                if (allowedEmails.Contains(userEmail))
                 {
                     logger.LogInformation("[SwaAuth] Authorized via &u= email: {email}", userEmail);
                     return true;
@@ -90,7 +109,7 @@ namespace Api
 
                 var userDetails = root.TryGetProperty("userDetails", out var ud) ? ud.GetString() : null;
                 logger.LogInformation("[SwaAuth] SWA userDetails='{email}'", userDetails);
-                if (userDetails != null && AllowedEmails.Contains(userDetails))
+                if (userDetails != null && GetAllowedEmails().Contains(userDetails))
                 {
                     logger.LogInformation("[SwaAuth] Authorized via SWA userDetails email: {email}", userDetails);
                     return true;

--- a/Client/Client.csproj
+++ b/Client/Client.csproj
@@ -116,5 +116,8 @@ namespace Client
 		<ProjectReference Include="..\Shared\Shared.csproj" />
 	</ItemGroup>
 
+	<ItemGroup>
+		<None Include="..\docs\**\*.md" />
+	</ItemGroup>
 
 </Project>

--- a/Client/Pages/PictureQuery.razor.cs
+++ b/Client/Pages/PictureQuery.razor.cs
@@ -6,6 +6,7 @@ using System.Text.Json;
 using System.Web;
 using WordScapeBlazorWasm.Services;
 using Client.Shared; // Add this for MyPix class
+using Client.Services; // UserRole, UserContextService
 
 namespace Client.Pages;
 
@@ -22,6 +23,7 @@ public partial class PictureQuery : IDisposable
     [Inject] private AlbumService AlbumService { get; set; } = null!;
     [Inject] private Client.Services.PictureService PictureService { get; set; } = null!;
     [Inject] private Client.Services.ApplicationInsightsLogger AppInsights { get; set; } = null!;
+    [Inject] private Client.Services.UserContextService UserContext { get; set; } = null!;
 
     // Parameters
     [Parameter]
@@ -174,6 +176,7 @@ public partial class PictureQuery : IDisposable
                 userMail = candidates.FirstOrDefault(c => !string.IsNullOrWhiteSpace(c)) ?? string.Empty;
                 Console.WriteLine($"Signed-in user resolved to: '{userMail}'");
                 isGuestUser = !string.Equals(userMail, OwnerEmail, StringComparison.OrdinalIgnoreCase);
+                UserContext.SetUser(userMail, isGuestUser ? UserRole.Guest : UserRole.Owner);
                 AppInsights.SetUserId(userMail);
 
                 if (isGuestUser)

--- a/Client/Program.cs
+++ b/Client/Program.cs
@@ -70,6 +70,9 @@ internal class Program
 
         // Add album service for OneDrive album operations
         builder.Services.AddScoped<AlbumService>();
+
+        // Tracks Owner/Guest/Anonymous role resolved after Graph /me call
+        builder.Services.AddSingleton<UserContextService>();
         
         builder.Services.AddMsalAuthentication(options =>
         {

--- a/Client/Services/UserContextService.cs
+++ b/Client/Services/UserContextService.cs
@@ -1,0 +1,33 @@
+namespace Client.Services
+{
+    /// <summary>
+    /// Tracks the resolved identity role of the signed-in user so that
+    /// NavMenu and other components can gate UI without re-running Graph calls.
+    /// </summary>
+    public enum UserRole { Anonymous, Guest, Owner }
+
+    public class UserContextService
+    {
+        public UserRole Role { get; private set; } = UserRole.Anonymous;
+        public string Email { get; private set; } = string.Empty;
+
+        public bool IsOwner => Role == UserRole.Owner;
+        public bool IsAuthenticated => Role != UserRole.Anonymous;
+
+        public event Action? OnChange;
+
+        public void SetUser(string email, UserRole role)
+        {
+            Email = email;
+            Role = role;
+            OnChange?.Invoke();
+        }
+
+        public void Clear()
+        {
+            Email = string.Empty;
+            Role = UserRole.Anonymous;
+            OnChange?.Invoke();
+        }
+    }
+}

--- a/Client/Shared/MainLayout.razor
+++ b/Client/Shared/MainLayout.razor
@@ -4,6 +4,7 @@
 
 @inherits LayoutComponentBase
 @inject ApplicationInsightsLogger AppInsights
+@inject UserContextService UserContext
 
 <div class="page">
     <div class="sidebar">
@@ -25,6 +26,8 @@
 @code {
     [CascadingParameter] private Task<AuthenticationState>? AuthenticationStateTask { get; set; }
 
+    private const string OwnerEmail = "calvin_hsia@live.com";
+
     protected override async Task OnInitializedAsync()
     {
         if (AuthenticationStateTask != null)
@@ -33,14 +36,30 @@
             var user = authState.User;
             if (user.Identity?.IsAuthenticated == true)
             {
-                // Prefer email claim, fall back to name or subject
-                var userId = user.FindFirst("preferred_username")?.Value
+                // Resolve email from MSAL claims — preferred_username is populated for
+                // personal Microsoft accounts via the 'consumers' authority
+                var email = user.FindFirst("preferred_username")?.Value
                           ?? user.FindFirst("email")?.Value
                           ?? user.FindFirst(System.Security.Claims.ClaimTypes.Email)?.Value
                           ?? user.FindFirst(System.Security.Claims.ClaimTypes.Name)?.Value
                           ?? user.Identity.Name
-                          ?? "authenticated";
-                AppInsights.SetUserId(userId);
+                          ?? string.Empty;
+
+                AppInsights.SetUserId(string.IsNullOrEmpty(email) ? "authenticated" : email);
+
+                // Resolve Owner/Guest role so NavMenu can show/hide "My Stuff" immediately.
+                // Guest = signed in + email in ALLOWED_EMAILS env var (same list as SwaAuthHelper).
+                // We can't read the env var client-side, so use the same hardcoded fallback
+                // logic: anything signed in and not owner is treated as Guest here.
+                // The API will enforce the real allowlist server-side.
+                var role = string.Equals(email, OwnerEmail, StringComparison.OrdinalIgnoreCase)
+                    ? UserRole.Owner
+                    : UserRole.Guest;
+                UserContext.SetUser(email, role);
+            }
+            else
+            {
+                UserContext.Clear();
             }
         }
     }

--- a/Client/Shared/NavMenu.razor
+++ b/Client/Shared/NavMenu.razor
@@ -1,6 +1,7 @@
 ﻿@inject IJSRuntime JSRuntime
 @inject NavigationManager NavigationManager
 @inject Client.Services.ApplicationInsightsLogger AppInsights
+@inject Client.Services.UserContextService UserContext
 @implements IDisposable
 
 <div class="top-row ps-3 navbar navbar-dark">
@@ -26,33 +27,32 @@
             </NavLink>
         </div>
 
-        <AuthorizeView>
-            <Authorized>
-                <div class="nav-section">
-                    <button class="nav-section-header" @onclick="() => ToggleSection(nameof(showAuthorized))" @onclick:stopPropagation="true">
-                        <span class="toggle-icon">@(showAuthorized ? "▼" : "▶")</span> My Stuff
-                    </button>
+        @if (UserContext.IsAuthenticated)
+        {
+            <div class="nav-section">
+                <button class="nav-section-header" @onclick="() => ToggleSection(nameof(showAuthorized))" @onclick:stopPropagation="true">
+                    <span class="toggle-icon">@(showAuthorized ? "▼" : "▶")</span> My Stuff @(UserContext.IsOwner ? "(Owner)" : "(Guest)")
+                </button>
+                <div class="nav-item px-3">
+                    <NavLink class="nav-link" href="Environment">
+                        <span class="oi oi-list-rich" aria-hidden="true"></span> Environment
+                    </NavLink>
+                </div>
+                @if (showAuthorized)
+                {
                     <div class="nav-item px-3">
-                        <NavLink class="nav-link" href="Environment">
-                            <span class="oi oi-list-rich" aria-hidden="true"></span> Environment
+                        <NavLink class="nav-link" href="PictureQuery">
+                            <span class="oi oi-camera-slr" aria-hidden="true"></span> Picture Query
                         </NavLink>
                     </div>
-                    @if (showAuthorized)
-                    {
-                        <div class="nav-item px-3">
-                            <NavLink class="nav-link" href="PictureQuery">
-                                <span class="oi oi-camera-slr" aria-hidden="true"></span> Picture Query
-                            </NavLink>
-                        </div>
-                        <div class="nav-item px-3">
-                            <NavLink class="nav-link" href="Albums">
-                                <span class="oi oi-book" aria-hidden="true"></span> Albums
-                            </NavLink>
-                        </div>
-                    }
-                </div>
-            </Authorized>
-        </AuthorizeView>
+                    <div class="nav-item px-3">
+                        <NavLink class="nav-link" href="Albums">
+                            <span class="oi oi-book" aria-hidden="true"></span> Albums
+                        </NavLink>
+                    </div>
+                }
+            </div>
+        }
 
         <div class="nav-section">
             <button class="nav-section-header" @onclick="() => ToggleSection(nameof(showGames))" @onclick:stopPropagation="true">
@@ -241,6 +241,7 @@
     protected override void OnInitialized()
     {
         NavigationManager.LocationChanged += OnLocationChanged;
+        UserContext.OnChange += StateHasChanged;
     }
 
     private void OnLocationChanged(object? sender, Microsoft.AspNetCore.Components.Routing.LocationChangedEventArgs e)
@@ -275,5 +276,6 @@
     public void Dispose()
     {
         NavigationManager.LocationChanged -= OnLocationChanged;
+        UserContext.OnChange -= StateHasChanged;
     }
 }

--- a/docs/AddingGuestUsers.md
+++ b/docs/AddingGuestUsers.md
@@ -3,7 +3,15 @@
 ## How it works
 
 Guest users see photos from the owner's (`Calvin_Hsia@live.com`) **OldPictures** OneDrive folder.
-The app identifies a guest as anyone who logs in with an email other than `OwnerEmail` in `PictureQuery.razor.cs`.
+The app resolves roles after the Graph `/me` call:
+
+| Role | Who | NavMenu |
+|---|---|---|
+| **Owner** | `calvin_hsia@live.com` | "My Stuff (Owner)" |
+| **Guest** | email in `ALLOWED_EMAILS` app setting | "My Stuff (Guest)" |
+| **Anonymous** | not signed in, or email not in allowlist | "My Stuff" hidden |
+
+`UserContextService` (singleton) holds the resolved role. `NavMenu.razor` subscribes to it and re-renders immediately after login.
 
 When a guest logs in, `PictureService.InitializeSharedContextAsync` resolves the shared folder in two steps:
 
@@ -12,6 +20,8 @@ When a guest logs in, `PictureService.InitializeSharedContextAsync` resolves the
 
 So **guests do not need to click a share link** before using the app — permission granted in OneDrive is sufficient.
 
+---
+
 ## Steps to add a new guest
 
 ### 1. Share the folder in OneDrive
@@ -19,34 +29,37 @@ So **guests do not need to click a share link** before using the app — permiss
 1. Go to [OneDrive](https://onedrive.live.com) and sign in as `Calvin_Hsia@live.com`
 2. Right-click **OldPictures** → **Share**
 3. Enter the guest's Microsoft account email
-4. Set permission to **Can view** (or **Can edit** if appropriate)
-5. Click **Send** (or **Copy link** — the guest does not need to click it for the app to work)
+4. Set permission to **Can view**
+5. Click **Send** (the guest does not need to click the link for the app to work)
 
-### 2. Add the guest email to `SwaAuthHelper.cs`
+### 2. Add the guest email to the Function App setting (no redeploy needed)
 
-The Azure Function API (`Api/SwaAuthHelper.cs`) has an email allowlist that gates access to `QueryPix` and other functions. Add the guest's email:
+1. Azure Portal → **Function App** (`CalvinHWebSite`) → **Configuration → Application settings**
+2. Find or create the setting `ALLOWED_EMAILS`
+3. Value is semicolon-separated, e.g.:
+   ```
+   calvin_hsia@live.com;calvin_hsia_test@outlook.com;pamelahsia@hotmail.com;newguest@example.com
+   ```
+4. Click **Save** → **Continue** → the function app restarts automatically
+5. The new guest can log in immediately — no code change or deployment needed
 
-```csharp
-private static readonly HashSet<string> AllowedEmails =
-    new(StringComparer.OrdinalIgnoreCase)
-    {
-        "calvin_hsia@live.com",
-        "calvin_hsia_test@outlook.com",
-        "pamelahsia@hotmail.com",   // ← add new guest here
-    };
-```
+> **Note:** The `ALLOWED_EMAILS` setting also works in PR preview environments since they use the same Function App configuration.
 
-Redeploy the API after this change.
+### 3. No other changes needed
 
-### 3. No other code changes needed
+- The `OwnerFolderContext` constants in `PictureService.cs` are tied to the **OldPictures folder**, not individual guests
+- Telemetry events automatically include the signed-in user's email via `AppInsights.SetUserId()` (set in `PictureQuery.razor.cs` after Graph `/me` resolves)
 
-The `OwnerFolderContext` constants in `PictureService.cs` are tied to the **OldPictures folder itself**, not to individual guests:
+---
 
-```csharp
-// Only the driveId is hardcoded — the OldPictures itemId is resolved at runtime by path:
-// GET /drives/{OwnerDriveId}/root:/Pictures/OldPictures?$select=id,name
-private const string OwnerDriveId = "00d69f3552cefc21";
-```
+## Architecture note
+
+The app uses **MSAL directly** for login — not SWA's `/.auth/login` flow. This means:
+- SWA's `staticwebapp.config.json` `allowedRoles` **cannot** gate API calls (SWA edge always sees MSAL users as `anonymous`)
+- API authorization is handled in `Api/SwaAuthHelper.cs` via the `&u=<email>` query param
+- The `ALLOWED_EMAILS` check happens at **function execution time**, not at the SWA edge
+
+See `.github/copilot-instructions.md` for the full authentication architecture explanation.
 
 Any Microsoft account that has been granted permission to **OldPictures** in OneDrive will automatically get access — no `appsettings.json` changes, no redeployment.
 


### PR DESCRIPTION
- Switch to MSAL-based client-side role resolution (Owner/Guest/Anonymous) after Graph `/me` call
- Manage allowed guest emails via `ALLOWED_EMAILS` app setting (no redeploy needed)
- Refactor API auth to read allowed emails at runtime with local fallback
- Add `UserContextService` singleton for role/email tracking and UI updates
- Update `NavMenu.razor` to gate "My Stuff" and show role label using `UserContextService`
- Set user role in `PictureQuery.razor.cs` after login
- Register `UserContextService` in DI
- Update docs for new guest management and auth flow
- Add markdown docs reference to `Client.csproj`