### PR TITLE
Improve mobile video streaming and playback reliability

### DIFF
--- a/Client/Pages/PictureQuery.razor
+++ b/Client/Pages/PictureQuery.razor
@@ -163,7 +163,7 @@
             <div class="lightbox-body">
                 <div class="lightbox-media" id="lightboxMedia">
                     <img id="imageMain" class="lightbox-img" />
-                    <video id="myVideo" class="lightbox-video" controls data-mime-type="video/mp4">
+                    <video id="myVideo" class="lightbox-video" controls playsinline data-mime-type="video/mp4">
                         video tag not supported
                     </video>
                     <button class="lightbox-nav lightbox-prev" @onclick="LightboxPrev" disabled="@(lightboxIndex <= 0)">❮</button>
@@ -430,24 +430,91 @@
         }
     };
 
+    // Sets a video element's src to a direct streaming URL (no blob, supports range requests).
+    // The browser streams natively — ideal for large video files on mobile.
+    window.setVideoUrl = (videoElementId, url, mimeType) => {
+        const video = document.getElementById(videoElementId);
+        if (!video) return;
+        // Revoke any previous blob URL
+        if (video._blobUrl) {
+            URL.revokeObjectURL(video._blobUrl);
+            video._blobUrl = null;
+        }
+        video._mutedRetry = false;
+        video.muted = false;
+        if (!url) {
+            video.removeAttribute('src');
+            video.load();
+            video.style.display = 'none';
+            return;
+        }
+        video.style.display = 'block';
+        video.dataset.mimeType = mimeType || 'video/mp4';
+        video.dataset.fileName = videoElementId;
+        const trackVideoEvent = (name, extra) => {
+            const props = {
+                fileName: video.dataset.fileName || videoElementId,
+                mimeType: video.dataset.mimeType,
+                readyState: String(video.readyState),
+                networkState: String(video.networkState),
+                duration: String(video.duration),
+                currentTime: String(video.currentTime),
+                userAgent: navigator.userAgent,
+                ...extra
+            };
+            console.log(`[VideoEvent] ${name}`, props);
+            if (typeof appInsights !== 'undefined') {
+                try { appInsights.trackEvent({ name: `Video_${name}`, properties: props }); } catch {}
+            }
+        };
+        video.onerror = () => {
+            const err = video.error;
+            trackVideoEvent('Error', { errorCode: String(err?.code), errorMessage: err?.message ?? '' });
+            console.error(`[setVideoUrl] video error code=${err?.code} message=${err?.message}`);
+            if (err?.code === 4 && !video._mutedRetry) {
+                console.warn(`[setVideoUrl] AAC not supported, retrying muted`);
+                video._mutedRetry = true;
+                video.muted = true;
+                video.load();
+                video.oncanplay = () => {
+                    video.oncanplay = null;
+                    video.play().catch(e => console.warn(`[setVideoUrl] muted retry play() failed: ${e.message}`));
+                };
+            }
+        };
+        video.oncanplay = () => {
+            video.oncanplay = null;
+            video.play().catch(e => {
+                trackVideoEvent('PlayFailed', { errorName: e.name, errorMessage: e.message });
+                console.warn(`[setVideoUrl] play() failed: ${e.name}: ${e.message}`);
+            });
+        };
+        video.src = url;
+        video.load();
+    };
+
     window.setImageSrc = async (imageElementId, imageStream) => {
         const imageCtrl = document.getElementById(imageElementId);
         if (imageCtrl) {
-            console.log(`Here in setImageSrc ${imageElementId} ${imageStream}`);
+
             if (imageStream === 'null') {
-                // Revoke any previous video blob URL before clearing the element
-                if (imageCtrl.tagName === 'VIDEO' && imageCtrl._blobUrl) {
-                    URL.revokeObjectURL(imageCtrl._blobUrl);
-                    imageCtrl._blobUrl = null;
-                }
-                imageCtrl.src = null;
-                imageCtrl.style.display = "none";
+            // Revoke any previous video blob URL before clearing the element
+            if (imageCtrl.tagName === 'VIDEO' && imageCtrl._blobUrl) {
+                URL.revokeObjectURL(imageCtrl._blobUrl);
+                imageCtrl._blobUrl = null;
+            }
+            imageCtrl._mutedRetry = false;
+            imageCtrl.src = null;
+            imageCtrl.style.display = "none";
             }
             else {
                 try {
                     const arrayBuffer = await imageStream.arrayBuffer();
                     console.log(`[setImageSrc] ${imageElementId} arrayBuffer size=${arrayBuffer.byteLength} tag=${imageCtrl.tagName}`);
                     if (imageCtrl.tagName === 'VIDEO') {
+                        // Reset mute state from any previous play before loading new content.
+                        imageCtrl.muted = false;
+                        imageCtrl._mutedRetry = false;
                         // Determine MIME type from element's data attribute set by C# before calling setImageSrc
                         const mimeType = imageCtrl.dataset.mimeType || 'video/mp4';
                         const blob = new Blob([arrayBuffer], { type: mimeType });
@@ -496,6 +563,19 @@
                             const err = imageCtrl.error;
                             trackVideoEvent('Error', { errorCode: String(err?.code), errorMessage: err?.message ?? '' });
                             console.error(`[setImageSrc] video error code=${err?.code} message=${err?.message}`);
+                            // errorCode 4 = MEDIA_ERR_SRC_NOT_SUPPORTED — common on Android when AAC
+                            // audio codec is not supported. Retry with muted=true to let the browser
+                            // skip audio decoding and still play the video track.
+                            if (err?.code === 4 && !imageCtrl._mutedRetry) {
+                                console.warn(`[setImageSrc] AAC not supported on this device, retrying muted`);
+                                imageCtrl._mutedRetry = true;
+                                imageCtrl.muted = true;
+                                imageCtrl.load();
+                                imageCtrl.oncanplay = () => {
+                                    imageCtrl.oncanplay = null;
+                                    imageCtrl.play().catch(e => console.warn(`[setImageSrc] muted retry play() failed: ${e.message}`));
+                                };
+                            }
                         };
                         imageCtrl.onstalled = () => {
                             trackVideoEvent('Stalled', {});

--- a/Client/Pages/PictureQuery.razor.cs
+++ b/Client/Pages/PictureQuery.razor.cs
@@ -61,6 +61,7 @@ public partial class PictureQuery : IDisposable
     private const string MSGraphEndPoint = @"https://graph.microsoft.com/v1.0/";
     private MyPix? mainPix = null;
     private bool isLoading = false;
+    private bool isMobile = false;
     private bool albumNameManuallyChanged = false;
     private bool wakeLockActive = false;
     private bool showLightbox = false;
@@ -242,6 +243,8 @@ public partial class PictureQuery : IDisposable
                 var dimensions = await JS.InvokeAsync<BrowserDimensions>("getDimensions");
                 browserDimensions = dimensions;
                 Console.WriteLine($"Got Dimensions {dimensions}");
+                isMobile = await JS.InvokeAsync<bool>("eval", "/(android|iphone|ipad|ipod|mobile)/i.test(navigator.userAgent)");
+                Console.WriteLine($"[PictureQuery] isMobile={isMobile}");
             }
             catch (Exception ex)
             {
@@ -682,9 +685,20 @@ public partial class PictureQuery : IDisposable
                             Task<byte[]> downloadTask;
                             lock (_lightboxCache)
                             {
-                                if (!_lightboxCache.TryGetValue(cacheKey, out downloadTask!))
+                                // Evict cancelled or faulted tasks — same as GetImageStreamAsync —
+                                // so a previously interrupted download doesn't block a fresh attempt.
+                                if (_lightboxCache.TryGetValue(cacheKey, out downloadTask!) &&
+                                    (downloadTask.IsFaulted || downloadTask.IsCanceled))
                                 {
-                                    downloadTask = _httpClient!.GetByteArrayAsync(kv.Value, ct);
+                                    _lightboxCache.Remove(cacheKey);
+                                    downloadTask = null!;
+                                }
+                                if (downloadTask == null)
+                                {
+                                    // Use CancellationToken.None for the actual byte download so that
+                                    // navigating away (which cancels ct) cannot store a cancelled/partial
+                                    // task in the cache and block the next attempt.
+                                    downloadTask = _httpClient!.GetByteArrayAsync(kv.Value, CancellationToken.None);
                                     _lightboxCache[cacheKey] = downloadTask;
                                 }
                             }
@@ -811,6 +825,12 @@ public partial class PictureQuery : IDisposable
             try
             {
                 var thumbSize = pix.IsVideo ? "" : "large";
+                // On mobile, videos stream by URL — no point downloading bytes into cache.
+                if (pix.IsVideo && isMobile)
+                {
+                    Console.WriteLine($"[Prefetch] Skipping video on mobile (streaming) {pix.FileName}");
+                    continue;
+                }
                 var cacheKey = $"{pix.FullFileName}|{thumbSize}";
                 bool needsFetch;
                 lock (_lightboxCache)
@@ -821,8 +841,6 @@ public partial class PictureQuery : IDisposable
                 if (needsFetch)
                 {
                     Console.WriteLine($"[Prefetch] Starting {pix.FileName}");
-                    // GetImageStreamAsync starts the download with CancellationToken.None
-                    // internally, so the bytes won't be truncated if ct fires mid-flight.
                     await GetImageStreamAsync(pix, thumbSize, ct);
                     Console.WriteLine($"[Prefetch] Completed {pix.FileName}");
                 }
@@ -849,7 +867,7 @@ public partial class PictureQuery : IDisposable
         mainPix = null;
         showLightbox = false;
         await JS.InvokeVoidAsync("setImageSrc", "imageMain", "null");
-        await JS.InvokeVoidAsync("setImageSrc", "myVideo", "null");
+        await JS.InvokeVoidAsync("setVideoUrl", "myVideo", null, null);
     }
 
     private async Task DoQueryAsync()
@@ -1352,10 +1370,27 @@ public partial class PictureQuery : IDisposable
                     ".mpg" => "video/mpeg",
                     _ => "video/mp4"
                 };
-                await JS.InvokeVoidAsync("eval", $"document.getElementById('myVideo').dataset.mimeType='{mimeType}'");
-                var strm = await GetImageStreamAsync(mainPix, "");
                 await JS.InvokeVoidAsync("setImageSrc", "imageMain", "null");
-                await JS.InvokeVoidAsync("setImageSrc", "myVideo", strm);
+                if (isMobile)
+                {
+                    // On mobile stream directly — avoids loading 100+ MB into WASM memory.
+                    var streamUrl = await AlbumService.GetDownloadUrlAsync(_httpClient!, mainPix);
+                    if (!string.IsNullOrEmpty(streamUrl))
+                    {
+                        await JS.InvokeVoidAsync("setVideoUrl", "myVideo", streamUrl, mimeType);
+                    }
+                    else
+                    {
+                        var strm = await GetImageStreamAsync(mainPix, "");
+                        await JS.InvokeVoidAsync("setImageSrc", "myVideo", strm);
+                    }
+                }
+                else
+                {
+                    // On desktop use the cached blob path (instant if prefetched).
+                    var strm = await GetImageStreamAsync(mainPix, "");
+                    await JS.InvokeVoidAsync("setImageSrc", "myVideo", strm);
+                }
             }
             else
             {
@@ -1395,7 +1430,7 @@ public partial class PictureQuery : IDisposable
         // Cache is intentionally kept — user may reopen the lightbox or tab back.
         // It is cleared in resetUI() when a new query runs.
         await JS.InvokeVoidAsync("setImageSrc", "imageMain", "null");
-        await JS.InvokeVoidAsync("setImageSrc", "myVideo", "null");
+        await JS.InvokeVoidAsync("setVideoUrl", "myVideo", null, null);
         StateHasChanged();
     }
 

--- a/Client/Services/AlbumService.cs
+++ b/Client/Services/AlbumService.cs
@@ -373,6 +373,24 @@ namespace WordScapeBlazorWasm.Services
         }
 
         /// <summary>
+        /// Gets the pre-authenticated CDN download URL (@microsoft.graph.downloadUrl) for a file.
+        /// This URL supports HTTP range requests, allowing the browser to stream video natively
+        /// without downloading the entire file into WASM memory first.
+        /// Returns null if the metadata call fails or the field is absent.
+        /// </summary>
+        public async Task<string?> GetDownloadUrlAsync(HttpClient httpClient, MyPix pix, CancellationToken cancellationToken = default)
+        {
+            var fileData = await GetFileMetadataAsync(httpClient, pix, cancellationToken);
+            if (fileData == null) return null;
+            if (fileData.Value.TryGetProperty("@microsoft.graph.downloadUrl", out var urlProp))
+                return urlProp.GetString();
+            // Fall back to /content redirect URL if the direct download URL is absent
+            if (fileData.Value.TryGetProperty("id", out var idProp))
+                return GetItemContentUrl(idProp.GetString()!);
+            return null;
+        }
+
+        /// <summary>
         /// Adds a file to an album
         /// </summary>
         public async Task<(bool success, string? errorMessage)> AddFileToAlbumAsync(


### PR DESCRIPTION
- Stream videos by direct URL on mobile using OneDrive CDN links
- Add setVideoUrl JS function for native video streaming
- Use playsinline on <video> for mobile compatibility
- Retry video playback muted if AAC audio unsupported
- Skip video prefetch on mobile to save memory
- Evict cancelled/faulted cache tasks to prevent stale loads
- Add isMobile detection and structured video event logging
- Update comments for clarity