### PR TITLE
Fcell

### DIFF
--- a/Client/Pages/PictureQuery.razor
+++ b/Client/Pages/PictureQuery.razor
@@ -432,7 +432,7 @@
 
     // Sets a video element's src to a direct streaming URL (no blob, supports range requests).
     // The browser streams natively — ideal for large video files on mobile.
-    window.setVideoUrl = (videoElementId, url, mimeType) => {
+    window.setVideoUrl = (videoElementId, url, mimeType, rotation) => {
         const video = document.getElementById(videoElementId);
         if (!video) return;
         // Revoke any previous blob URL
@@ -446,11 +446,15 @@
             video.removeAttribute('src');
             video.load();
             video.style.display = 'none';
+            video.style.transform = '';
+            video.style.width = '';
+            video.style.height = '';
             return;
         }
         video.style.display = 'block';
         video.dataset.mimeType = mimeType || 'video/mp4';
         video.dataset.fileName = videoElementId;
+        applyVideoRotation(video, rotation || 0);
         const trackVideoEvent = (name, extra) => {
             const props = {
                 fileName: video.dataset.fileName || videoElementId,
@@ -493,19 +497,42 @@
         video.load();
     };
 
+    // Applies CSS rotation to compensate for MP4 container rotation metadata that
+    // mobile browsers don't auto-correct on <video> elements.
+    // For 90/270 deg rotations the video dimensions are swapped so it fills the container.
+    function applyVideoRotation(video, degrees) {
+        video.style.transform = '';
+        video.style.width = '';
+        video.style.height = '';
+        if (!degrees || degrees === 0 || degrees === 360) return;
+        video.style.transform = `rotate(${degrees}deg)`;
+        // When rotated 90 or 270 deg the natural width/height are swapped.
+        // Set explicit dimensions so the rotated video fills its container correctly.
+        if (degrees === 90 || degrees === 270) {
+            video.style.width = '100vh';   // fill along the rotated axis
+            video.style.height = '100vw';
+        }
+        console.log(`[VideoRotation] applied ${degrees}deg`);
+    }
+
     window.setImageSrc = async (imageElementId, imageStream) => {
         const imageCtrl = document.getElementById(imageElementId);
         if (imageCtrl) {
 
             if (imageStream === 'null') {
-            // Revoke any previous video blob URL before clearing the element
-            if (imageCtrl.tagName === 'VIDEO' && imageCtrl._blobUrl) {
-                URL.revokeObjectURL(imageCtrl._blobUrl);
-                imageCtrl._blobUrl = null;
-            }
-            imageCtrl._mutedRetry = false;
-            imageCtrl.src = null;
-            imageCtrl.style.display = "none";
+                // Revoke any previous video blob URL before clearing the element
+                if (imageCtrl.tagName === 'VIDEO' && imageCtrl._blobUrl) {
+                    URL.revokeObjectURL(imageCtrl._blobUrl);
+                    imageCtrl._blobUrl = null;
+                }
+                imageCtrl._mutedRetry = false;
+                if (imageCtrl.tagName === 'VIDEO') {
+                    imageCtrl.style.transform = '';
+                    imageCtrl.style.width = '';
+                    imageCtrl.style.height = '';
+                }
+                imageCtrl.src = null;
+                imageCtrl.style.display = "none";
             }
             else {
                 try {

--- a/Client/Pages/PictureQuery.razor.cs
+++ b/Client/Pages/PictureQuery.razor.cs
@@ -207,6 +207,12 @@ public partial class PictureQuery : IDisposable
                 {
                     Console.WriteLine("Owner login — using personal OneDrive.");
                 }
+
+                // Now that userMail is resolved, it is safe to resume interrupted album creation.
+                if (resumedProgress != null)
+                {
+                    _ = Task.Run(async () => await ResumeWithQueryAsync());
+                }
             }
         }
         catch (AccessTokenNotAvailableException ex)
@@ -372,10 +378,8 @@ public partial class PictureQuery : IDisposable
                         Console.WriteLine($"Found resumable progress: last processed index {savedProgress.LastProcessedIndex}");
 
                         await InvokeAsync(StateHasChanged); // Update UI first
-
-                        // ✅ Re-execute the query first to populate myPixes, then resume album creation
-                        _ = Task.Run(async () => await ResumeWithQueryAsync());
-
+                        // Defer resume until after OnInitializedAsync resolves userMail.
+                        // Setting the flag here; the actual kick-off happens at the end of OnInitializedAsync.
                         return; // Don't remove - we'll use this for resume
                     }
                 }

--- a/Client/Pages/PictureQuery.razor.cs
+++ b/Client/Pages/PictureQuery.razor.cs
@@ -1378,10 +1378,10 @@ public partial class PictureQuery : IDisposable
                 if (isMobile)
                 {
                     // On mobile stream directly — avoids loading 100+ MB into WASM memory.
-                    var streamUrl = await AlbumService.GetDownloadUrlAsync(_httpClient!, mainPix);
+                    var (streamUrl, rotation) = await AlbumService.GetDownloadUrlAsync(_httpClient!, mainPix);
                     if (!string.IsNullOrEmpty(streamUrl))
                     {
-                        await JS.InvokeVoidAsync("setVideoUrl", "myVideo", streamUrl, mimeType);
+                        await JS.InvokeVoidAsync("setVideoUrl", "myVideo", streamUrl, mimeType, rotation);
                     }
                     else
                     {

--- a/Client/Services/AlbumService.cs
+++ b/Client/Services/AlbumService.cs
@@ -373,21 +373,29 @@ namespace WordScapeBlazorWasm.Services
         }
 
         /// <summary>
-        /// Gets the pre-authenticated CDN download URL (@microsoft.graph.downloadUrl) for a file.
-        /// This URL supports HTTP range requests, allowing the browser to stream video natively
-        /// without downloading the entire file into WASM memory first.
-        /// Returns null if the metadata call fails or the field is absent.
+        /// Gets the pre-authenticated CDN download URL (@microsoft.graph.downloadUrl) and the
+        /// video rotation angle (from video.rotation in Graph metadata) for a file.
+        /// The URL supports HTTP range requests for native browser streaming.
+        /// Returns (null, 0) if the metadata call fails.
         /// </summary>
-        public async Task<string?> GetDownloadUrlAsync(HttpClient httpClient, MyPix pix, CancellationToken cancellationToken = default)
+        public async Task<(string? Url, int Rotation)> GetDownloadUrlAsync(HttpClient httpClient, MyPix pix, CancellationToken cancellationToken = default)
         {
             var fileData = await GetFileMetadataAsync(httpClient, pix, cancellationToken);
-            if (fileData == null) return null;
+            if (fileData == null) return (null, 0);
+
+            string? url = null;
             if (fileData.Value.TryGetProperty("@microsoft.graph.downloadUrl", out var urlProp))
-                return urlProp.GetString();
-            // Fall back to /content redirect URL if the direct download URL is absent
-            if (fileData.Value.TryGetProperty("id", out var idProp))
-                return GetItemContentUrl(idProp.GetString()!);
-            return null;
+                url = urlProp.GetString();
+            else if (fileData.Value.TryGetProperty("id", out var idProp))
+                url = GetItemContentUrl(idProp.GetString()!);
+
+            // video.rotation is set by the phone's camera (e.g. 90 for portrait-recorded MP4)
+            int rotation = 0;
+            if (fileData.Value.TryGetProperty("video", out var videoProp) &&
+                videoProp.TryGetProperty("rotation", out var rotProp))
+                rotation = rotProp.GetInt32();
+
+            return (url, rotation);
         }
 
         /// <summary>


### PR DESCRIPTION
Handle video rotation metadata for correct playback

Add support for reading video.rotation from Graph metadata and applying CSS transforms to <video> elements for proper orientation on mobile browsers. Update setVideoUrl and setImageSrc to reset transform and sizing when clearing. AlbumService.GetDownloadUrlAsync now returns both URL and rotation.

Defer album resume until userMail is resolved

Resume of interrupted album creation is now triggered only after userMail is available in OnInitializedAsync. This ensures album creation uses the correct user context and avoids running resume logic before authentication is complete.