### PR TITLE
Log video load events and details for debugging

### DIFF
--- a/Client/Pages/PictureQuery.razor
+++ b/Client/Pages/PictureQuery.razor
@@ -471,6 +471,7 @@
                 try { appInsights.trackEvent({ name: `Video_${name}`, properties: props }); } catch {}
             }
         };
+        trackVideoEvent('Loaded', { rotation: String(rotation || 0), hasUrl: String(!!url) });
         video.onerror = () => {
             const err = video.error;
             trackVideoEvent('Error', { errorCode: String(err?.code), errorMessage: err?.message ?? '' });

--- a/Client/Pages/PictureQuery.razor.cs
+++ b/Client/Pages/PictureQuery.razor.cs
@@ -1379,6 +1379,7 @@ public partial class PictureQuery : IDisposable
                 {
                     // On mobile stream directly — avoids loading 100+ MB into WASM memory.
                     var (streamUrl, rotation) = await AlbumService.GetDownloadUrlAsync(_httpClient!, mainPix);
+                    Console.WriteLine($"[Video] {mainPix.FileName} rotation={rotation} hasUrl={!string.IsNullOrEmpty(streamUrl)}");
                     if (!string.IsNullOrEmpty(streamUrl))
                     {
                         await JS.InvokeVoidAsync("setVideoUrl", "myVideo", streamUrl, mimeType, rotation);


### PR DESCRIPTION
Added `trackVideoEvent('Loaded', ...)` in JS to log video load events with rotation and URL info. Added a `Console.WriteLine` in `PictureQuery.razor.cs` to output video filename, rotation, and stream URL presence when loading videos on mobile. These changes improve diagnostics and event tracking.