### PR TITLE
Update PictureQuery media type and UI for clarity

### DIFF
--- a/Client/Pages/PictureQuery.razor
+++ b/Client/Pages/PictureQuery.razor
@@ -39,7 +39,7 @@
                 <div class="filter-item">
                     <label>Type:</label>
                     <select id="MediaType" @bind="@mediaType" class="media-type-select">
-                        <option value="pic&amp;mov">pic&amp;mov</option>
+                        <option value="picmov">pic&amp;mov</option>
                         <option value="pic">pic</option>
                         <option value="mov">mov</option>
                     </select>
@@ -216,7 +216,7 @@
                     {
                         @:<tr>
                     }
-                    <td style="vertical-align:top;"><img id="@imgname" title="@pix.AltText" @onclick="()=> MyThumbClick(pix)" style="max-width:360px;max-height:270px;width:auto;height:auto;object-fit:contain;cursor:pointer;" /><div class="pix-alttext">@pix.AltText</div></td>
+                    <td style="vertical-align:top;"><img id="@imgname" title="@pix.AltText" @onclick="()=> MyThumbClick(pix)" style="max-width:360px;max-height:270px;width:auto;height:auto;object-fit:contain;cursor:pointer;" /><div class="pix-alttext @(pix.IsVideo ? "pix-alttext-video" : "")">@pix.AltText</div></td>
                     cntr++;
                     if (cntr % NumberPerRow == NumberPerRow-1 || cntr == NumberPerPage)
                     {
@@ -236,7 +236,7 @@
                     </div>
                     <div class="help-dialog-body">
                         <h4>Query Results</h4>
-                        <p>Query results are paginated thumbnails from my OneDrive. Click a thumb for all full images. Desktop browser will cache. Mobile streams videos from OneDrive</p>
+                        <p>Query results are paginated thumbnails from my OneDrive. Click a thumb for all full images. Desktop browser will cache. Mobile streams videos from OneDrive. Movie thumbnail text has light green background.</p>
                         <h4>Filter</h4>
                         <ul>
                             <li>Enter text to search photo/movie descriptions (case-insensitive).</li>
@@ -286,7 +286,7 @@
 
     .lightbox-toolbar {
         display: flex;
-        align-items: center;
+        align-items: flex-start;
         justify-content: space-between;
         padding: 6px 12px;
         background: rgba(0,0,0,0.85);
@@ -300,10 +300,14 @@
         text-align: center;
         font-size: 13px;
         overflow: hidden;
-        text-overflow: ellipsis;
-        white-space: nowrap;
+        word-break: break-word;
+        white-space: normal;
         padding: 0 10px;
         color: #ddd;
+        display: -webkit-box;
+        -webkit-line-clamp: 3;
+        -webkit-box-orient: vertical;
+        line-height: 1.3;
     }
 
     .lightbox-btn {
@@ -594,8 +598,15 @@
     .pix-alttext {
         font-size: 12px;
         color: #333;
+        background: none;
         word-break: break-word;
         max-width: 360px;
+    }
+
+    .pix-alttext.pix-alttext-video {
+        background: #d4edda;
+        border-radius: 3px;
+        padding: 2px 4px;
     }
 
     @@media (max-width: 768px) {

--- a/Client/Pages/PictureQuery.razor.cs
+++ b/Client/Pages/PictureQuery.razor.cs
@@ -47,7 +47,7 @@ public partial class PictureQuery : IDisposable
     private string date1 = "1/1/1950";
     private string date2 = "1/1/2030";
     private string notesFilter = @"weight";
-    private string mediaType = "pic&mov";
+    private string mediaType = "picmov";
     private bool publishToAlbum = true;
     private string albumName = "weight"; // Initialize with default filter value
     private int albumMaxItems = 100; // Default album item limit
@@ -433,10 +433,11 @@ public partial class PictureQuery : IDisposable
                 throw new Exception("Authentication token not available");
             }
 
+            var effectiveMediaType = mediaType == "picmov" ? "" : mediaType;
             var qpart = $"Date1={HttpUtility.UrlEncode(date1)}&Date2={HttpUtility.UrlEncode(date2)}&MaxPix={maxpix}&NotesFilter={HttpUtility.UrlEncode(notesFilter)}";
-            if (!string.IsNullOrEmpty(mediaType))
+            if (!string.IsNullOrEmpty(effectiveMediaType))
             {
-                qpart += $"&MediaType={mediaType.ToLower()}";
+                qpart += $"&MediaType={effectiveMediaType.ToLower()}";
             }
 
             var urlQuery = $"/api/QueryPix?{qpart}";
@@ -580,7 +581,11 @@ public partial class PictureQuery : IDisposable
                 if (root.TryGetProperty("notesFilter", out var notesFilterEl))
                     notesFilter = notesFilterEl.GetString() ?? notesFilter;
                 if (root.TryGetProperty("mediaType", out var mediaTypeEl))
-                    mediaType = mediaTypeEl.GetString() ?? mediaType;
+                {
+                    var saved = mediaTypeEl.GetString() ?? mediaType;
+                    // Migrate old values: "" (blank text input) and "pic&mov"/"pic&amp;mov" → "picmov"
+                    mediaType = (saved == "" || saved == "pic&mov" || saved == "pic&amp;mov") ? "picmov" : saved;
+                }
                 if (root.TryGetProperty("date1", out var date1El))
                     date1 = date1El.GetString() ?? date1;
                 if (root.TryGetProperty("date2", out var date2El))
@@ -903,8 +908,8 @@ public partial class PictureQuery : IDisposable
                 return;
             }
 
-            // Translate "pic&mov" (meaning both) to empty string which the API treats as both
-            var effectiveMediaType = mediaType == "pic&mov" ? "" : mediaType;
+            // Translate "picmov" (meaning both) to empty string which the API treats as both
+            var effectiveMediaType = mediaType == "picmov" ? "" : mediaType;
             var qpart = $"Date1={HttpUtility.UrlEncode(date1)}&Date2={HttpUtility.UrlEncode(date2)}&MaxPix={maxpix}&NotesFilter={HttpUtility.UrlEncode(notesFilter)}";
             if (!string.IsNullOrEmpty(effectiveMediaType))
             {
@@ -913,6 +918,8 @@ public partial class PictureQuery : IDisposable
 
             // SWA replaces the Authorization header — pass the email as a query param instead.
             var urlQuery = $"/api/QueryPix?{qpart}&u={Uri.EscapeDataString(userMail)}";
+            Console.WriteLine($"[PictureQuery] DoQueryAsync URL: mediaType='{mediaType}' effectiveMediaType='{effectiveMediaType}' url={urlQuery}");
+            _ = AppInsights.TrackEvent("PictureQueryUrl", new Dictionary<string, string> { ["mediaType"] = mediaType, ["effectiveMediaType"] = effectiveMediaType, ["url"] = urlQuery });
 
             var request = new HttpRequestMessage(HttpMethod.Get, urlQuery);
             var response = await Http.SendAsync(request);

--- a/Client/Services/PictureService.cs
+++ b/Client/Services/PictureService.cs
@@ -31,7 +31,7 @@ public class PictureService
 
     private readonly TelemetryService _telemetry;
 
-    public PictureService(TelemetryService telemetry)
+    public PictureService(TelemetryService telemetry)  
     {
         _telemetry = telemetry;
     }
@@ -55,20 +55,20 @@ public class PictureService
             // --- Primary: search sharedWithMe ---
             var sharedWithMeError = await TryInitFromSharedWithMeAsync(httpClient);
             if (SharedContext != null)
-                return null; // success
+                return null; // success 
 
             // --- Fallback: resolve OldPictures by path on the owner's drive.
-                    // This works even if the recipient has never clicked a share link, and
-                    // avoids hardcoding an itemId that could be wrong.
-                    await _telemetry.TrackEventAsync("SharedContext.FallbackToOwnerIds");
-                    var resolvedItemId = await ResolveOwnerFolderItemIdAsync(httpClient);
-                    if (resolvedItemId != null)
-                    {
-                        SharedContext = new SharedDriveContext(OwnerDriveId, resolvedItemId);
-                        await _telemetry.TrackEventAsync("SharedContext.Initialized",
-                            new Dictionary<string, string> { ["source"] = "ownerPath", ["itemId"] = resolvedItemId });
-                        return null;
-                    }
+            // This works even if the recipient has never clicked a share link, and
+            // avoids hardcoding an itemId that could be wrong.
+            await _telemetry.TrackEventAsync("SharedContext.FallbackToOwnerIds");
+            var resolvedItemId = await ResolveOwnerFolderItemIdAsync(httpClient);
+            if (resolvedItemId != null)
+            {
+                SharedContext = new SharedDriveContext(OwnerDriveId, resolvedItemId);
+                await _telemetry.TrackEventAsync("SharedContext.Initialized",
+                    new Dictionary<string, string> { ["source"] = "ownerPath", ["itemId"] = resolvedItemId });
+                return null;
+            }
 
             return sharedWithMeError;
         }


### PR DESCRIPTION
- Use "picmov" (no ampersand) for "pictures and movies" filter value throughout UI and logic
- Migrate old mediaType values to "picmov" for consistency
- Query logic: "picmov" translates to empty string for API
- Add versioned console log and AppInsights event for query URL
- Movie thumbnails: alt text now has light green background
- Update help dialog to mention movie thumbnail highlight
- Improve lightbox title CSS for multi-line wrapping
- Minor CSS and whitespace fixes in PictureService