### PR TITLE
on mobile, the lightbox Back and Download buttons take a lot of space…

### DIFF
--- a/Client/Pages/PictureQuery.razor
+++ b/Client/Pages/PictureQuery.razor
@@ -163,10 +163,10 @@
         }
         <div id="lightbox" class="lightbox-overlay @(showLightbox ? "lightbox-visible" : "")">
             <div class="lightbox-toolbar">
-                <button class="lightbox-btn" @onclick="LightboxClose">← Back</button>
+                <button class="lightbox-btn" @onclick="LightboxClose" title="Back"><svg xmlns="http://www.w3.org/2000/svg" width="18" height="18" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2.2" stroke-linecap="round" stroke-linejoin="round"><path d="M19 12H5"/><path d="M12 19l-7-7 7-7"/></svg></button>
                 <span class="lightbox-title">@mainPix?.AltText</span>
                 <button class="lightbox-btn rotate-btn" @onclick="RotateCurrentMediaAsync" title="Rotate 90° CW"><svg xmlns="http://www.w3.org/2000/svg" width="18" height="18" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2.2" stroke-linecap="round" stroke-linejoin="round"><path d="M21 2v6h-6"/><path d="M3 12a9 9 0 0 1 15-6.7L21 8"/><path d="M3 22v-6h6"/><path d="M21 12a9 9 0 0 1-15 6.7L3 16"/></svg></button>
-                <button class="lightbox-btn" @onclick="MyImgClickMain" disabled="@(mainPix == null)">⬇ Download</button>
+                <button class="lightbox-btn" @onclick="MyImgClickMain" disabled="@(mainPix == null)" title="Download"><svg xmlns="http://www.w3.org/2000/svg" width="18" height="18" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2.2" stroke-linecap="round" stroke-linejoin="round"><path d="M21 15v4a2 2 0 0 1-2 2H5a2 2 0 0 1-2-2v-4"/><polyline points="7 10 12 15 17 10"/><line x1="12" y1="15" x2="12" y2="3"/></svg></button>
             </div>
             <div class="lightbox-body">
                 <div class="lightbox-media" id="lightboxMedia">


### PR DESCRIPTION
…. Replace with standard icons, like the rotate button