### PR TITLE
Responsive nav overlay for wide PictureQuery pages

### DIFF
--- a/Client/Pages/PictureQuery.razor
+++ b/Client/Pages/PictureQuery.razor
@@ -133,14 +133,10 @@
         }
 
         @{
-            NumberPerRow = 1;
-            if (browserDimensions.Width > 2000)
-            {
-                NumberPerRow = 3;
-            } else if (browserDimensions.Width > 800)
-            {
-                NumberPerRow = 2;
-            }
+            // Calculate columns based on available width divided by thumbnail width (~380px incl. padding).
+            // Mobile (≤640px): always 1 column; otherwise as many as fit.
+            const int thumbWidth = 380;
+            NumberPerRow = browserDimensions.Width <= 640 ? 1 : Math.Max(1, browserDimensions.Width / thumbWidth);
             if (myPixes.Count > 0)
             {
                 <div class="info-line">Pg={@this.PageNumber} | Results=@NumberTotalPix | PerPage=@NumberPerPage | MaxPix=@maxpix</div>

--- a/Client/Program.cs
+++ b/Client/Program.cs
@@ -73,6 +73,9 @@ internal class Program
 
         // Tracks Owner/Guest/Anonymous role resolved after Graph /me call
         builder.Services.AddSingleton<UserContextService>();
+
+        // Shared nav collapse state for hamburger in top bar on wide pages
+        builder.Services.AddSingleton<NavMenuState>();
         
         builder.Services.AddMsalAuthentication(options =>
         {

--- a/Client/Services/NavMenuState.cs
+++ b/Client/Services/NavMenuState.cs
@@ -1,0 +1,35 @@
+namespace Client.Services
+{
+    /// <summary>
+    /// Shared state so MainLayout's top-bar hamburger can toggle NavMenu on wide pages.
+    /// </summary>
+    public class NavMenuState
+    {
+        public bool IsCollapsed { get; private set; } = true;
+        public event Action? OnChange;
+
+        public void Toggle()
+        {
+            IsCollapsed = !IsCollapsed;
+            OnChange?.Invoke();
+        }
+
+        public void Collapse()
+        {
+            if (!IsCollapsed)
+            {
+                IsCollapsed = true;
+                OnChange?.Invoke();
+            }
+        }
+
+        public void SetCollapsed(bool collapsed)
+        {
+            if (IsCollapsed != collapsed)
+            {
+                IsCollapsed = collapsed;
+                OnChange?.Invoke();
+            }
+        }
+    }
+}

--- a/Client/Shared/MainLayout.razor
+++ b/Client/Shared/MainLayout.razor
@@ -5,14 +5,29 @@
 @inherits LayoutComponentBase
 @inject ApplicationInsightsLogger AppInsights
 @inject UserContextService UserContext
+@inject NavigationManager NavigationManager
+@inject NavMenuState NavMenuState
+@implements IDisposable
 
 <div class="page">
-    <div class="sidebar">
+    @if (!IsWidePage)
+    {
+        <div class="sidebar">
+            <NavMenu />
+        </div>
+    }
+    else
+    {
+        <!-- overlay nav for wide pages -->
         <NavMenu />
-    </div>
+    }
 
     <main>
-        <div class="top-row px-4 auth">
+        <div class="top-row px-4 auth @(IsWidePage ? "wide-page-top" : "")">
+            @if (IsWidePage)
+            {
+                <button class="hamburger-btn" title="Navigation menu" @onclick="NavMenuState.Toggle">☰</button>
+            }
             <LoginDisplay/>
             <a href="https://docs.microsoft.com/aspnet/" target="_blank">About</a>
         </div>
@@ -27,6 +42,25 @@
     [CascadingParameter] private Task<AuthenticationState>? AuthenticationStateTask { get; set; }
 
     private const string OwnerEmail = "calvin_hsia@live.com";
+
+    private bool IsWidePage => NavigationManager.ToBaseRelativePath(NavigationManager.Uri).ToLowerInvariant().StartsWith("picturequery");
+
+    protected override void OnInitialized()
+    {
+        NavigationManager.LocationChanged += OnLocationChanged;
+        NavMenuState.OnChange += StateHasChanged;
+    }
+
+    private void OnLocationChanged(object? sender, Microsoft.AspNetCore.Components.Routing.LocationChangedEventArgs e)
+    {
+        StateHasChanged();
+    }
+
+    public void Dispose()
+    {
+        NavigationManager.LocationChanged -= OnLocationChanged;
+        NavMenuState.OnChange -= StateHasChanged;
+    }
 
     protected override async Task OnInitializedAsync()
     {

--- a/Client/Shared/MainLayout.razor.css
+++ b/Client/Shared/MainLayout.razor.css
@@ -67,6 +67,23 @@ main {
         top: 0;
     }
 
+    .hamburger-btn {
+        background: none;
+        border: 1px solid #aaa;
+        border-radius: 4px;
+        padding: 0.2rem 0.55rem;
+        margin-right: auto;  /* pushes everything else to the right */
+        cursor: pointer;
+        font-size: 1.25rem;
+        line-height: 1;
+        color: #333;
+        flex-shrink: 0;
+    }
+
+    .hamburger-btn:hover {
+        background-color: rgba(0,0,0,0.08);
+    }
+
     .top-row {
         position: sticky;
         top: 0;

--- a/Client/Shared/NavMenu.razor
+++ b/Client/Shared/NavMenu.razor
@@ -2,24 +2,28 @@
 @inject NavigationManager NavigationManager
 @inject Client.Services.ApplicationInsightsLogger AppInsights
 @inject Client.Services.UserContextService UserContext
+@inject Client.Services.NavMenuState NavMenuState
 @implements IDisposable
 
-<div class="top-row ps-3 navbar navbar-dark">
-    <div class="container-fluid">
-        <a class="navbar-brand" href="">
-            <span class="site-name">Calvin's Web Site</span>
-            @if (!string.IsNullOrEmpty(GetCurrentPageName()))
-            {
-                <span class="page-name"> - @GetCurrentPageName()</span>
-            }
-        </a>
-        <button title="Navigation menu" class="navbar-toggler" @onclick="ToggleNavMenu">
-            <span class="navbar-toggler-icon"></span>
-        </button>
+@if (!IsWidePage)
+{
+    <div class="top-row ps-3 navbar navbar-dark">
+        <div class="container-fluid">
+            <a class="navbar-brand" href="">
+                <span class="site-name">Calvin's Web Site</span>
+                @if (!string.IsNullOrEmpty(GetCurrentPageName()))
+                {
+                    <span class="page-name"> - @GetCurrentPageName()</span>
+                }
+            </a>
+            <button title="Navigation menu" class="navbar-toggler" @onclick="ToggleNavMenu">
+                <span class="navbar-toggler-icon"></span>
+            </button>
+        </div>
     </div>
-</div>
+}
 
-<div class="@NavMenuCssClass nav-scrollable" @onclick="ToggleNavMenu">
+<div class="@NavMenuCssClass nav-scrollable @(IsWidePage ? "wide-page-overlay" : "")" @onclick="ToggleNavMenu">
     <nav class="flex-column">
         <div class="nav-item px-3">
             <NavLink class="nav-link" href="" Match="NavLinkMatch.All">
@@ -161,17 +165,17 @@
 </div>
 
 @code {
-    private bool collapseNavMenu = true;
     private bool showAuthorized = true;
+    private bool IsWidePage => NavigationManager.ToBaseRelativePath(NavigationManager.Uri).ToLowerInvariant().StartsWith("picturequery");
     private bool showGames = true;
     private bool showDesktopApps = true;
 
-    private string? NavMenuCssClass => collapseNavMenu ? "collapse" : null;
+    private string? NavMenuCssClass => NavMenuState.IsCollapsed ? "collapse" : null;
 
     private void ToggleNavMenu()
     {
-        collapseNavMenu = !collapseNavMenu;
-        
+        NavMenuState.Toggle();
+
         // Also toggle the game sidebar if we're on GameLayout
         InvokeAsync(async () =>
         {
@@ -242,10 +246,13 @@
     {
         NavigationManager.LocationChanged += OnLocationChanged;
         UserContext.OnChange += StateHasChanged;
+        NavMenuState.OnChange += StateHasChanged;
+        NavMenuState.SetCollapsed(IsWidePage);
     }
 
     private void OnLocationChanged(object? sender, Microsoft.AspNetCore.Components.Routing.LocationChangedEventArgs e)
     {
+        NavMenuState.SetCollapsed(IsWidePage);
         StateHasChanged();
         
         // Track page view in Application Insights
@@ -277,5 +284,6 @@
     {
         NavigationManager.LocationChanged -= OnLocationChanged;
         UserContext.OnChange -= StateHasChanged;
+        NavMenuState.OnChange -= StateHasChanged;
     }
 }

--- a/Client/Shared/NavMenu.razor.css
+++ b/Client/Shared/NavMenu.razor.css
@@ -118,6 +118,24 @@
         display: block;
     }
 
+    /* On wide-content pages the nav is a fixed overlay panel */
+    .wide-page-overlay {
+        position: fixed;
+        top: 0;
+        left: 0;
+        width: 260px;
+        height: 100vh;
+        z-index: 1000;
+        overflow-y: auto;
+        background-image: linear-gradient(180deg, rgb(5, 39, 103) 0%, #3a0647 70%);
+        box-shadow: 4px 0 16px rgba(0,0,0,0.4);
+    }
+
+    /* When collapsed on wide page, hide it */
+    .wide-page-overlay.collapse {
+        display: none;
+    }
+
     /* Hide page name on wide screens */
     .navbar-brand .page-name {
         display: none;


### PR DESCRIPTION
Adds NavMenuState service for shared nav collapse state. MainLayout displays a hamburger button on wide PictureQuery pages to toggle the nav overlay. NavMenu renders as a fixed overlay with collapse/expand logic and updated CSS. Refactors column calculation for responsive layout. Cleans up event handlers to prevent leaks.