### PR TITLE
Always collapse NavMenu on init

### DIFF
--- a/Client/Shared/NavMenu.razor
+++ b/Client/Shared/NavMenu.razor
@@ -247,7 +247,7 @@
         NavigationManager.LocationChanged += OnLocationChanged;
         UserContext.OnChange += StateHasChanged;
         NavMenuState.OnChange += StateHasChanged;
-        NavMenuState.SetCollapsed(IsWidePage);
+        NavMenuState.SetCollapsed(true); // always start collapsed; CSS forces open on desktop non-wide pages
     }
 
     private void OnLocationChanged(object? sender, Microsoft.AspNetCore.Components.Routing.LocationChangedEventArgs e)


### PR DESCRIPTION
NavMenu now always starts collapsed regardless of page width; CSS handles forced open state for desktop as needed.