### PR TITLE
Add ApiHttpService for auto-auth API calls; refactor usage

### DIFF
--- a/Api/PictureSettings.json
+++ b/Api/PictureSettings.json
@@ -10,7 +10,7 @@
     "StartDate": "1950-06-01",
     "EndDate": "2124-06-30"
   },
-  "pamelahsia@hotmail.com": {
+  "00000000-0000-0000-06de-79953eadc8f1": {
     "label": "pamelahsia@hotmail.com",
     "filter": ""
   },
@@ -18,7 +18,7 @@
     "label": "contourdeto@gmail.com",
     "filter": ""
   },
-  "tylerhsia@hotmail.com": {
+  "00000000-0000-0000-1252-794d26e10914": {
     "label": "tylerhsia@hotmail.com",
     "filter": ""
   },

--- a/Client/Pages/Environment.razor
+++ b/Client/Pages/Environment.razor
@@ -1,8 +1,10 @@
 ﻿@page "/Environment"
 @using System;
 @using Client.Shared
+@using Client.Services
 
 @inject HttpClient Http
+@inject ApiHttpService ApiHttp
 
 <h1>Environment</h1>
 
@@ -35,7 +37,7 @@ else
             strEnvironment = "hi " + DateTime.Now.ToString();
             sysObjJson = await new EnvInfo().GetDataAsync();
 
-            var res = await Http.GetAsync("/api/EnvInfo");
+            var res = await ApiHttp.GetAsync("/api/EnvInfo");
             serverJson = await res.Content.ReadAsStringAsync();
 
 

--- a/Client/Pages/PictureQuery.razor.cs
+++ b/Client/Pages/PictureQuery.razor.cs
@@ -20,6 +20,7 @@ public partial class PictureQuery : IDisposable
     [Inject] private IJSRuntime JS { get; set; } = null!;
     [Inject] private IAccessTokenProvider TokenProvider { get; set; } = null!;
     [Inject] private AuthTokenHelper AuthToken { get; set; } = null!;
+    [Inject] private Client.Services.ApiHttpService ApiHttp { get; set; } = null!;
     [Inject] private AlbumService AlbumService { get; set; } = null!;
     [Inject] private Client.Services.PictureService PictureService { get; set; } = null!;
     [Inject] private Client.Services.ApplicationInsightsLogger AppInsights { get; set; } = null!;
@@ -49,7 +50,7 @@ public partial class PictureQuery : IDisposable
     private string date2 = "1/1/2030";
     private string notesFilter = @"weight";
     private string mediaType = "all";
-    private bool publishToAlbum = true;
+    private bool publishToAlbum = false;
     private string albumName = "weight"; // Initialize with default filter value
     private int albumMaxItems = 100; // Default album item limit
     private bool isPublishing = false;
@@ -436,8 +437,6 @@ public partial class PictureQuery : IDisposable
                 // AuthTokenHelper already handles the redirect
                 throw new Exception("Authentication token not available");
             }
-            // Use ID token (JWT) for API auth — Graph access token is opaque for MSA accounts
-            var apiAuthToken = await AuthToken.GetIdTokenAsync() ?? token;
             var effectiveMediaType = mediaType == "all" ? "" : mediaType;
             var qpart = $"Date1={HttpUtility.UrlEncode(date1)}&Date2={HttpUtility.UrlEncode(date2)}&MaxPix={maxpix}&NotesFilter={HttpUtility.UrlEncode(notesFilter)}";
             if (!string.IsNullOrEmpty(effectiveMediaType))
@@ -447,7 +446,7 @@ public partial class PictureQuery : IDisposable
 
             var urlQuery = $"/api/QueryPix?{qpart}";
 
-            var serverJson = await FetchQueryPixAsync(urlQuery, apiAuthToken);
+            var serverJson = await FetchQueryPixAsync(urlQuery);
             var pixes = JsonSerializer.Deserialize<MyPix[]>(serverJson);
 
             // Clear and repopulate myPixes
@@ -528,14 +527,12 @@ public partial class PictureQuery : IDisposable
     /// The caller's MSAL bearer token is sent in the X-Token header; the API validates it
     /// cryptographically so no spoofable identity parameter is needed.
     /// </summary>
-    private async Task<string> FetchQueryPixAsync(string urlQuery, string token)
+    private async Task<string> FetchQueryPixAsync(string urlQuery)
     {
         for (int attempt = 0; attempt < 2; attempt++)
         {
             var request = new HttpRequestMessage(HttpMethod.Get, urlQuery);
-            // Send the live bearer token — API validates signature, issuer, and expiry
-            if (!string.IsNullOrEmpty(token))
-                request.Headers.Add("X-Token", token);
+            await ApiHttp.AttachTokenAsync(request);
             var response = await Http.SendAsync(request);
             var body = await response.Content.ReadAsStringAsync();
 
@@ -987,11 +984,10 @@ public partial class PictureQuery : IDisposable
             // Diagnostic: log token shape so we can see if it's a real JWT or opaque token
             LogTokenDiagnostics(token);
 
-            // For API authorization we need a JWT (the Graph token for MSA is opaque).
-            // The ID token is always a signed JWT with oid — get it from the MSAL cache.
+            // Log the ID token diagnostics (retrieved inside ApiHttp.AttachTokenAsync below)
             var idToken = await AuthToken.GetIdTokenAsync();
             LogTokenDiagnostics(idToken ?? "", label: "IdToken");
-            var apiAuthToken = idToken ?? token; // fallback to access token if ID token unavailable
+            var apiAuthToken = idToken ?? token; // used only for OID display on 401
 
             // Translate "all" (meaning both) to empty string which the API treats as both
             var effectiveMediaType = mediaType == "all" ? "" : mediaType;
@@ -1007,8 +1003,7 @@ public partial class PictureQuery : IDisposable
             _ = AppInsights.TrackEvent("PictureQueryUrl", new Dictionary<string, string> { ["mediaType"] = mediaType, ["effectiveMediaType"] = effectiveMediaType, ["url"] = urlQuery });
 
             var request = new HttpRequestMessage(HttpMethod.Get, urlQuery);
-            // Send the ID token — a signed JWT with oid — not the opaque Graph access token
-            request.Headers.Add("X-Token", apiAuthToken);
+            await ApiHttp.AttachTokenAsync(request);  // attaches X-Token automatically
             var response = await Http.SendAsync(request);
             var serverJson = await response.Content.ReadAsStringAsync();
             if (response.StatusCode != System.Net.HttpStatusCode.OK)

--- a/Client/Program.cs
+++ b/Client/Program.cs
@@ -64,6 +64,9 @@ internal class Program
         
         // Add authentication helper for centralized token handling
         builder.Services.AddScoped<AuthTokenHelper>();
+
+        // Wraps HttpClient for /api/* calls — auto-attaches X-Token header
+        builder.Services.AddScoped<Client.Services.ApiHttpService>();
         
         // Add picture service for shared OneDrive folder context
         builder.Services.AddScoped<Client.Services.PictureService>();

--- a/Client/Services/ApiHttpService.cs
+++ b/Client/Services/ApiHttpService.cs
@@ -1,0 +1,106 @@
+using BlazorWasm.Services;
+using System;
+using System.Net.Http;
+using System.Text.Json;
+using System.Threading.Tasks;
+
+namespace Client.Services
+{
+    /// <summary>
+    /// Wraps HttpClient for calls to /api/* endpoints, automatically attaching the
+    /// MSAL ID token in the X-Token header so every API call is authenticated without
+    /// each page needing to fetch and attach the token itself.
+    ///
+    /// Token refresh: MSAL refreshes the ID token when the access token is refreshed.
+    /// GetIdTokenAsync reads from the MSAL localStorage cache. If the cached ID token
+    /// is expired or absent, we trigger an access token refresh first (which causes MSAL
+    /// to also write a fresh ID token to the cache), then retry.
+    /// </summary>
+    public class ApiHttpService
+    {
+        private readonly HttpClient _http;
+        private readonly AuthTokenHelper _authToken;
+
+        public ApiHttpService(HttpClient http, AuthTokenHelper authToken)
+        {
+            _http = http;
+            _authToken = authToken;
+        }
+
+        /// <summary>
+        /// Sends a GET to the given URL with the X-Token header attached.
+        /// Returns the HttpResponseMessage — caller reads content and checks status.
+        /// </summary>
+        public async Task<HttpResponseMessage> GetAsync(string url)
+        {
+            var request = new HttpRequestMessage(HttpMethod.Get, url);
+            await AttachTokenAsync(request);
+            return await _http.SendAsync(request);
+        }
+
+        /// <summary>
+        /// Attaches a fresh, non-expired MSAL ID token to the request as X-Token.
+        /// If the cached ID token is missing or expired, triggers an MSAL access-token
+        /// refresh first (which also refreshes the ID token in localStorage), then retries.
+        /// </summary>
+        public async Task AttachTokenAsync(HttpRequestMessage request)
+        {
+            var token = await GetFreshIdTokenAsync();
+            if (!string.IsNullOrEmpty(token))
+                request.Headers.TryAddWithoutValidation("X-Token", token);
+        }
+
+        /// <summary>
+        /// Returns a non-expired ID token, refreshing via MSAL if necessary.
+        /// </summary>
+        private async Task<string?> GetFreshIdTokenAsync()
+        {
+            var idToken = await _authToken.GetIdTokenAsync();
+
+            if (!string.IsNullOrEmpty(idToken) && !IsTokenExpiredOrExpiringSoon(idToken))
+                return idToken;
+
+            // Token is missing or about to expire — trigger an access token refresh.
+            // MSAL writes a fresh ID token to localStorage as a side-effect.
+            Console.WriteLine("[ApiHttpService] ID token missing or expiring — refreshing via MSAL access token request");
+            var accessToken = await _authToken.GetAccessTokenAsync(showExpiredMessage: false, delayBeforeRedirect: 0);
+            if (string.IsNullOrEmpty(accessToken))
+            {
+                // GetAccessTokenAsync already redirected to login
+                return null;
+            }
+
+            // Re-read the ID token from the now-refreshed cache
+            idToken = await _authToken.GetIdTokenAsync();
+            if (string.IsNullOrEmpty(idToken))
+                Console.WriteLine("[ApiHttpService] Still no ID token after access token refresh — API call will fail");
+
+            return idToken;
+        }
+
+        /// <summary>
+        /// Returns true if the JWT is expired or expires within the next 5 minutes.
+        /// Reads the exp claim from the payload without verifying the signature (display/timing use only).
+        /// </summary>
+        private static bool IsTokenExpiredOrExpiringSoon(string jwt, int bufferMinutes = 5)
+        {
+            try
+            {
+                var parts = jwt.Split('.');
+                if (parts.Length < 2) return true;
+
+                var pad = parts[1].Replace('-', '+').Replace('_', '/');
+                pad = pad.PadRight(pad.Length + (4 - pad.Length % 4) % 4, '=');
+                var json = System.Text.Encoding.UTF8.GetString(Convert.FromBase64String(pad));
+                using var doc = JsonDocument.Parse(json);
+                if (doc.RootElement.TryGetProperty("exp", out var expProp))
+                {
+                    var exp = DateTimeOffset.FromUnixTimeSeconds(expProp.GetInt64());
+                    return exp < DateTimeOffset.UtcNow.AddMinutes(bufferMinutes);
+                }
+            }
+            catch { /* malformed token — treat as expired */ }
+            return true;
+        }
+    }
+}


### PR DESCRIPTION
Introduced ApiHttpService to centralize attaching MSAL ID tokens to /api/* requests and handle token refresh. Refactored PictureQuery and Environment pages to use the new service. Registered ApiHttpService in DI. Changed publishToAlbum default to false. Updated PictureSettings.json to use GUID keys for some users.